### PR TITLE
feat: hide field/section for a given survey from rule in datastore

### DIFF
--- a/src/domain/entities/AMRSurveyModule.ts
+++ b/src/domain/entities/AMRSurveyModule.ts
@@ -1,8 +1,21 @@
-import { NamedRef } from "./Ref";
+import { Id, NamedRef } from "./Ref";
 
 export type SURVEY_TYPE = "NationalSurvey" | "HospitalSurvey" | "SupranationalSurvey";
 
 type UserGroups = { captureAccess: NamedRef[]; readAccess: NamedRef[]; adminAccess: NamedRef[] };
+
+type SurveyRuleType = "HIDEFIELD" | "HIDESECTION";
+
+type Rule = {
+    id: Id;
+    type: SurveyRuleType;
+    toHide: Id[]; //DataElementIds or SectionIds
+};
+
+export type SurveyRule = {
+    surveyId: Id;
+    rules: Rule[];
+};
 
 export interface AMRSurveyModule {
     id: string;
@@ -10,4 +23,5 @@ export interface AMRSurveyModule {
     color: string;
     surveyPrograms: NamedRef[];
     userGroups: UserGroups;
+    rulesBySurvey: SurveyRule[];
 }

--- a/src/domain/entities/AMRSurveyModule.ts
+++ b/src/domain/entities/AMRSurveyModule.ts
@@ -13,7 +13,7 @@ type Rule = {
 };
 
 export type SurveyRule = {
-    surveyId: Id;
+    formId: Id;
     rules: Rule[];
 };
 
@@ -23,5 +23,5 @@ export interface AMRSurveyModule {
     color: string;
     surveyPrograms: NamedRef[];
     userGroups: UserGroups;
-    rulesBySurvey: SurveyRule[];
+    rulesBySurvey: { surveyId: Id; surveyRules: SurveyRule[] }[];
 }

--- a/src/domain/entities/__tests__/moduleFixtures.ts
+++ b/src/domain/entities/__tests__/moduleFixtures.ts
@@ -37,6 +37,7 @@ export function createModuleList(): AMRSurveyModule[] {
                     },
                 ],
             },
+            rulesBySurvey: [],
         },
         {
             color: "#E23A75",
@@ -68,6 +69,7 @@ export function createModuleList(): AMRSurveyModule[] {
                     },
                 ],
             },
+            rulesBySurvey: [],
         },
     ];
 }

--- a/src/domain/usecases/ApplyInitialRulesToSurveyUseCase.ts
+++ b/src/domain/usecases/ApplyInitialRulesToSurveyUseCase.ts
@@ -1,24 +1,38 @@
-import { SurveyRule } from "../entities/AMRSurveyModule";
+import { AMRSurveyModule } from "../entities/AMRSurveyModule";
 import { Questionnaire, QuestionnarieM } from "../entities/Questionnaire/Questionnaire";
+import { Id } from "../entities/Ref";
 
 export class ApplyInitialRulesToSurveyUseCase {
-    public execute(questionnaire: Questionnaire, surveyRules: SurveyRule[]): Questionnaire {
+    public execute(
+        questionnaire: Questionnaire,
+        module: AMRSurveyModule | undefined,
+        currentPPSSurveyForm: Id | undefined,
+        currentPrevalenceSurveyForm: Id | undefined
+    ): Questionnaire {
         //1. Apply program rules defined in metadata
         const questionnaireWithProgramRules =
             QuestionnarieM.applyProgramRulesOnQuestionnaireInitialLoad(questionnaire);
 
         //2. Apply survey rules defined in the datastore
-        const currentSurveyRules = surveyRules.find(
-            surveyRule => surveyRule.surveyId === questionnaire.id
+
+        const currentParentId =
+            module?.name === "PPS" ? currentPPSSurveyForm : currentPrevalenceSurveyForm;
+
+        const currentSurveyRules = module?.rulesBySurvey.find(
+            rule => rule.surveyId === currentParentId
+        )?.surveyRules;
+
+        const currentFormRule = currentSurveyRules?.find(
+            surveyRule => surveyRule.formId === questionnaire.id
         );
 
         //no rules to apply, return questionnaire with program rules
-        if (!currentSurveyRules) return questionnaireWithProgramRules;
+        if (!currentFormRule) return questionnaireWithProgramRules;
         else {
             const questionnaireWithSurveyRules =
                 QuestionnarieM.applySurveyRulesOnQuestionnaireInitialLoad(
                     questionnaire,
-                    currentSurveyRules
+                    currentFormRule
                 );
             return questionnaireWithSurveyRules;
         }

--- a/src/domain/usecases/ApplyInitialRulesToSurveyUseCase.ts
+++ b/src/domain/usecases/ApplyInitialRulesToSurveyUseCase.ts
@@ -1,7 +1,26 @@
+import { SurveyRule } from "../entities/AMRSurveyModule";
 import { Questionnaire, QuestionnarieM } from "../entities/Questionnaire/Questionnaire";
 
 export class ApplyInitialRulesToSurveyUseCase {
-    public execute(questionnaire: Questionnaire): Questionnaire {
-        return QuestionnarieM.applyAllRulesOnQuestionnaireInitialLoad(questionnaire);
+    public execute(questionnaire: Questionnaire, surveyRules: SurveyRule[]): Questionnaire {
+        //1. Apply program rules defined in metadata
+        const questionnaireWithProgramRules =
+            QuestionnarieM.applyProgramRulesOnQuestionnaireInitialLoad(questionnaire);
+
+        //2. Apply survey rules defined in the datastore
+        const currentSurveyRules = surveyRules.find(
+            surveyRule => surveyRule.surveyId === questionnaire.id
+        );
+
+        //no rules to apply, return questionnaire with program rules
+        if (!currentSurveyRules) return questionnaireWithProgramRules;
+        else {
+            const questionnaireWithSurveyRules =
+                QuestionnarieM.applySurveyRulesOnQuestionnaireInitialLoad(
+                    questionnaire,
+                    currentSurveyRules
+                );
+            return questionnaireWithSurveyRules;
+        }
     }
 }

--- a/src/domain/usecases/GetAllAccesibleModulesUseCase.ts
+++ b/src/domain/usecases/GetAllAccesibleModulesUseCase.ts
@@ -35,8 +35,7 @@ export class GetAllAccesibleModulesUseCase {
                                 (module.userGroups.readAccess.length === 0 &&
                                     accesibleSurveysInModule.length > 0))
                         ) {
-                            module.surveyPrograms = accesibleSurveysInModule;
-                            return module;
+                            return { ...module, surveyPrograms: accesibleSurveysInModule };
                         }
                     });
 

--- a/src/domain/usecases/GetSurveyUseCase.ts
+++ b/src/domain/usecases/GetSurveyUseCase.ts
@@ -34,114 +34,126 @@ export class GetSurveyUseCase {
     ): FutureData<Questionnaire> {
         const programId = getProgramId(surveyFormType);
         if (parentPPSSurveyId) {
-            return this.surveyReporsitory
-                .getForm(programId, undefined, undefined)
-                .flatMap(questionnaire => {
-                    if (questionnaire.stages && questionnaire.stages[0]) {
-                        const updatedSections: QuestionnaireSection[] =
-                            questionnaire.stages[0].sections.map(section => {
-                                //PPS Questionnaires have only 1 stage
-                                const isSurveyIdOrWardIdSection =
-                                    section.questions.find(
-                                        question =>
-                                            question.id === SURVEY_ID_DATAELEMENT_ID ||
-                                            question.id === SURVEY_ID_PATIENT_DATAELEMENT_ID ||
-                                            question.id === WARD_ID_DATAELEMENT_ID
-                                    ) !== undefined;
-
-                                if (isSurveyIdOrWardIdSection) {
-                                    const updatedQuestions: Question[] = section.questions.map(
-                                        question => {
-                                            const isSurveyIdQuestion =
-                                                question.id === SURVEY_ID_DATAELEMENT_ID ||
-                                                question.id === SURVEY_ID_PATIENT_DATAELEMENT_ID;
-                                            const isWardIdQuestion =
-                                                question.id === WARD_ID_DATAELEMENT_ID;
-
-                                            if (isSurveyIdQuestion && question.type === "text") {
-                                                //Survey Id Question, pre-populate value to parent survey id
-                                                const updatedSurveyIdQuestion: Question = {
-                                                    ...question,
-                                                    value: parentPPSSurveyId,
-                                                };
-                                                return updatedSurveyIdQuestion;
-                                            } else if (
-                                                isWardIdQuestion &&
-                                                question.type === "text"
-                                            ) {
-                                                //Survey Id Question, pre-populate value to parent survey id
-                                                const updatedWardIdQuestion: Question = {
-                                                    ...question,
-                                                    value: parentWardRegisterId,
-                                                };
-                                                return updatedWardIdQuestion;
-                                            } else {
-                                                //Not survey id question, return without any update
-                                                return question;
-                                            }
-                                        }
-                                    );
-
-                                    return {
-                                        ...section,
-                                        questions: updatedQuestions,
-                                    };
-                                }
-
-                                //Not survey id section, return without any update
-                                return section;
-                            });
-
-                        const updatedStage: QuestionnaireStage = {
-                            ...questionnaire.stages[0],
-                            sections: updatedSections,
-                        };
-
-                        return Future.success({ ...questionnaire, stages: [updatedStage] });
-                    } else {
-                        return Future.success(questionnaire);
-                    }
-                });
+            return this.getPPSSurveyForm(programId, parentPPSSurveyId, parentWardRegisterId);
         } else if (parentPrevalenceSurveyId) {
-            return this.surveyReporsitory
-                .getForm(programId, undefined, undefined)
-                .flatMap(questionnaire => {
-                    //The Survey Id is always part of Tracked Entity which is the Profile Section i.e questionnaire.entity
+            return this.getPrevalenceSurveyForm(programId, parentPrevalenceSurveyId);
+        } else return this.surveyReporsitory.getForm(programId, undefined, undefined);
+    }
 
-                    if (!questionnaire.entity) {
-                        return Future.success(questionnaire);
-                    }
-                    const updatedEntityQuestions: Question[] = questionnaire.entity.questions.map(
-                        question => {
-                            const isSurveyIdQuestion =
-                                question.id === SURVEY_ID_FACILITY_LEVEL_DATAELEMENT_ID ||
-                                question.id === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_SSTF ||
-                                question.id === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_CRL ||
-                                question.id === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_PIS ||
-                                question.id === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_SRL ||
-                                question.id === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_CRF;
+    getPPSSurveyForm(
+        programId: Id,
+        parentPPSSurveyId: Id | undefined,
+        parentWardRegisterId: Id | undefined
+    ): FutureData<Questionnaire> {
+        return this.surveyReporsitory
+            .getForm(programId, undefined, undefined)
+            .flatMap(questionnaire => {
+                if (questionnaire.stages && questionnaire.stages[0]) {
+                    const updatedSections: QuestionnaireSection[] =
+                        questionnaire.stages[0].sections.map(section => {
+                            //PPS Questionnaires have only 1 stage
+                            const isSurveyIdOrWardIdSection =
+                                section.questions.find(
+                                    question =>
+                                        question.id === SURVEY_ID_DATAELEMENT_ID ||
+                                        question.id === SURVEY_ID_PATIENT_DATAELEMENT_ID ||
+                                        question.id === WARD_ID_DATAELEMENT_ID
+                                ) !== undefined;
 
-                            if (isSurveyIdQuestion && question.type === "text") {
+                            if (isSurveyIdOrWardIdSection) {
+                                const updatedQuestions: Question[] = section.questions.map(
+                                    question => {
+                                        const isSurveyIdQuestion =
+                                            question.id === SURVEY_ID_DATAELEMENT_ID ||
+                                            question.id === SURVEY_ID_PATIENT_DATAELEMENT_ID;
+                                        const isWardIdQuestion =
+                                            question.id === WARD_ID_DATAELEMENT_ID;
+
+                                        if (isSurveyIdQuestion && question.type === "text") {
+                                            //Survey Id Question, pre-populate value to parent survey id
+                                            const updatedSurveyIdQuestion: Question = {
+                                                ...question,
+                                                value: parentPPSSurveyId,
+                                            };
+                                            return updatedSurveyIdQuestion;
+                                        } else if (isWardIdQuestion && question.type === "text") {
+                                            //Survey Id Question, pre-populate value to parent survey id
+                                            const updatedWardIdQuestion: Question = {
+                                                ...question,
+                                                value: parentWardRegisterId,
+                                            };
+                                            return updatedWardIdQuestion;
+                                        } else {
+                                            //Not survey id question, return without any update
+                                            return question;
+                                        }
+                                    }
+                                );
+
                                 return {
-                                    ...question,
-                                    value: parentPrevalenceSurveyId,
+                                    ...section,
+                                    questions: updatedQuestions,
                                 };
-                            } else {
-                                return question;
                             }
-                        }
-                    );
 
-                    const updatedEntity: QuestionnaireEntity = {
-                        ...questionnaire.entity,
-                        questions: updatedEntityQuestions,
+                            //Not survey id section, return without any update
+                            return section;
+                        });
+
+                    const updatedStage: QuestionnaireStage = {
+                        ...questionnaire.stages[0],
+                        sections: updatedSections,
                     };
 
-                    return Future.success({
-                        ...questionnaire,
-                        entity: updatedEntity,
-                    });
+                    return Future.success({ ...questionnaire, stages: [updatedStage] });
+                } else {
+                    return Future.success(questionnaire);
+                }
+            });
+    }
+
+    getPrevalenceSurveyForm(
+        programId: Id,
+        parentPrevalenceSurveyId: Id
+    ): FutureData<Questionnaire> {
+        return this.surveyReporsitory
+            .getForm(programId, undefined, undefined)
+            .flatMap(questionnaire => {
+                //The Survey Id is always part of Tracked Entity which is the Profile Section i.e questionnaire.entity
+
+                if (!questionnaire.entity) {
+                    return Future.success(questionnaire);
+                }
+                const updatedEntityQuestions: Question[] = questionnaire.entity.questions.map(
+                    question => {
+                        const isSurveyIdQuestion =
+                            question.id === SURVEY_ID_FACILITY_LEVEL_DATAELEMENT_ID ||
+                            question.id === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_SSTF ||
+                            question.id === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_CRL ||
+                            question.id === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_PIS ||
+                            question.id === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_SRL ||
+                            question.id === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_CRF;
+
+                        if (isSurveyIdQuestion && question.type === "text") {
+                            return {
+                                ...question,
+                                value: parentPrevalenceSurveyId,
+                            };
+                        } else {
+                            return question;
+                        }
+                    }
+                );
+
+                const updatedEntity: QuestionnaireEntity = {
+                    ...questionnaire.entity,
+                    questions: updatedEntityQuestions,
+                };
+
+                return Future.success({
+                    ...questionnaire,
+                    entity: updatedEntity,
                 });
-        } else return this.surveyReporsitory.getForm(programId, undefined, undefined);
+            });
     }
 }

--- a/src/webapp/components/survey/hook/useSurveyForm.ts
+++ b/src/webapp/components/survey/hook/useSurveyForm.ts
@@ -97,7 +97,9 @@ export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | und
                             const processedQuestionnaire =
                                 compositionRoot.surveys.applyInitialRules.execute(
                                     questionnaireForm,
-                                    currentModule?.rulesBySurvey ?? []
+                                    currentModule,
+                                    currentPPSSurveyForm?.id,
+                                    currentPrevalenceSurveyForm?.id
                                 );
                             setQuestionnaire(processedQuestionnaire);
                         } else setQuestionnaire(questionnaireForm);
@@ -134,7 +136,9 @@ export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | und
                             const processedQuestionnaire =
                                 compositionRoot.surveys.applyInitialRules.execute(
                                     questionnaireWithData,
-                                    currentModule?.rulesBySurvey ?? []
+                                    currentModule,
+                                    currentPPSSurveyForm?.id,
+                                    currentPrevalenceSurveyForm?.id
                                 );
                             setQuestionnaire(processedQuestionnaire);
                         } else setQuestionnaire(questionnaireWithData);


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8693rkzwt

### :memo: Implementation
1. Based on the rules defined in datastore for each parent survey instance, apply HIDEFIELD/HIDESECTION rule for each child form.
2. refactor code in src/domain/usecases/GetSurveyUseCase.ts to break up into functions.

NOTE : datastore structure for survey rules
 ```
"rulesBySurvey": [
      {
        "surveyId": "p91asa2vebZ",
        "surveyRules": [
          {
            "formId": "mesnCzaLc7u",
            "rules": [
              {
                "id": "1",
                "toHide": [
                  "SCYImStXDHM"
                ],
                "type": "HIDEFIELD"
              },
              {
                "id": "2",
                "toHide": [
                  "mIHOCwjHtyu"
                ],
                "type": "HIDESECTION"
              }
            ]
          }
        ]
      }
    ],

```
### :video_camera: Screenshots/Screen capture

https://github.com/EyeSeeTea/amr-surveys/assets/83749675/1c200566-dabf-4e43-aa9a-b40910448c93



### :fire: Notes to the tester
