### PR TITLE
Read only functionality

### DIFF
--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-01-10T09:57:59.737Z\n"
+"POT-Creation-Date: 2024-01-15T12:42:39.990Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -88,6 +88,11 @@ msgstr ""
 msgid "HOSP"
 msgstr ""
 
+msgid ""
+"This survey has other surveys associated with it.\n"
+" Please delete all associated surveys, before you can delete this one."
+msgstr ""
+
 msgid "Survey deleted!"
 msgstr ""
 
@@ -107,6 +112,9 @@ msgid "Patient Name"
 msgstr ""
 
 msgid "Action"
+msgstr ""
+
+msgid "Loading..."
 msgstr ""
 
 msgid "No data found..."

--- a/src/domain/entities/Program.ts
+++ b/src/domain/entities/Program.ts
@@ -1,3 +1,5 @@
+import { OptionType } from "../utils/optionsHelper";
+
 export type ImportStrategy = "CREATE" | "UPDATE" | "CREATE_AND_UPDATE" | "DELETE";
 
 export type ProgramCountMap = {
@@ -6,6 +8,6 @@ export type ProgramCountMap = {
 }[];
 
 export type ProgramOptionCountMap = {
-    option: string;
+    option: OptionType;
     count: number;
 }[];

--- a/src/domain/usecases/GetChildCountUseCase.ts
+++ b/src/domain/usecases/GetChildCountUseCase.ts
@@ -36,27 +36,27 @@ export class GetChildCountUseCase {
                 const programOptionsMap: ProgramOptionCountMap = programCountMap.map(pc => {
                     if (pc.id === PREVALENCE_SAMPLE_SHIP_TRACK_FORM_ID) {
                         return {
-                            option: `List Sample Shipments (${pc.count})`,
+                            option: { label: `List Sample Shipments (${pc.count})` },
                             count: pc.count,
                         };
                     } else if (pc.id === PREVALENCE_CENTRAL_REF_LAB_FORM_ID) {
                         return {
-                            option: `List Central Ref Labs (${pc.count})`,
+                            option: { label: `List Central Ref Labs (${pc.count})` },
                             count: pc.count,
                         };
                     } else if (pc.id === PREVALENCE_PATHOGEN_ISO_STORE_TRACK_ID) {
                         return {
-                            option: `List Pathogen Isolates Logs (${pc.count})`,
+                            option: { label: `List Pathogen Isolates Logs (${pc.count})` },
                             count: pc.count,
                         };
                     } else if (pc.id === PREVALENCE_SUPRANATIONAL_REF_LAB_ID) {
                         return {
-                            option: `List Supranational Refs (${pc.count})`,
+                            option: { label: `List Supranational Refs (${pc.count})` },
                             count: pc.count,
                         };
                     } else {
                         return {
-                            option: ``,
+                            option: { label: "" },
                             count: 0,
                         };
                     }

--- a/src/domain/utils/PPSProgramsHelper.ts
+++ b/src/domain/utils/PPSProgramsHelper.ts
@@ -13,6 +13,19 @@ import {
     PREVALENCE_SURVEY_FORM_ID,
 } from "../../data/entities/D2Survey";
 import { Survey, SURVEY_FORM_TYPES } from "../entities/Survey";
+import {
+    DefaultFormOptions,
+    OptionType,
+    PPSCountryFormOptions,
+    PPSHospitalFormOptions,
+    PPSSurveyDefaultOptions,
+    PPSSurveyHospitalOptions,
+    PPSSurveyNationalOptions,
+    PPSWardFormOptions,
+    PrevalenceCaseReportFormOptions,
+    PrevalenceFacilityLevelFormOptions,
+    PrevalenceSurveyFormOptions,
+} from "./optionsHelper";
 
 export const PREVALENCE_PATIENT_OPTIONS = [
     "Case Report",
@@ -112,53 +125,44 @@ export const getChildSurveyType = (
 
 export const getSurveyOptions = (
     surveyFormType: SURVEY_FORM_TYPES,
+    hasReadAccess: boolean,
+    hasCaptureAccess: boolean,
     ppsSurveyType?: string
-): string[] => {
+): OptionType[] => {
     switch (surveyFormType) {
         case "PPSSurveyForm": {
             switch (ppsSurveyType) {
                 case "NATIONAL":
-                    return ["Edit", "Add New Country", "List Country", "Delete"];
+                    return PPSSurveyNationalOptions(hasReadAccess, hasCaptureAccess);
                 case "HOSP":
-                    return ["Edit", "Add New Hospital", "List Hospitals", "Delete"];
+                    return PPSSurveyHospitalOptions(hasReadAccess, hasCaptureAccess);
                 case "SUPRANATIONAL":
                 default:
-                    return ["Edit", "Add New Country", "List Countries", "Delete"];
+                    return PPSSurveyDefaultOptions(hasReadAccess, hasCaptureAccess);
             }
         }
         case "PPSCountryQuestionnaire":
-            return ["Edit", "Add New Hospital", "List Hospitals", "Delete"];
+            return PPSCountryFormOptions(hasReadAccess, hasCaptureAccess);
         case "PPSHospitalForm":
-            return ["Edit", "Add New Ward", "List Wards", "Delete"];
+            return PPSHospitalFormOptions(hasReadAccess, hasCaptureAccess);
         case "PPSWardRegister":
-            return ["Edit", "Add New Patient", "List Patients", "Delete"];
+            return PPSWardFormOptions(hasReadAccess, hasCaptureAccess);
 
         case "PrevalenceSurveyForm":
-            return ["Edit", "Add New Facility", "List Facilities", "Delete"];
+            return PrevalenceSurveyFormOptions(hasReadAccess, hasCaptureAccess);
 
         case "PrevalenceFacilityLevelForm":
-            return ["Edit", "Add New Patient", "List Patients", "Delete"];
+            return PrevalenceFacilityLevelFormOptions(hasReadAccess, hasCaptureAccess);
 
         case "PrevalenceCaseReportForm":
-            return [
-                "Edit",
-                "Add New Sample Shipment",
-                "List Sample Shipments",
-                "Add New Central Ref Lab",
-                "List Central Ref Labs",
-                "Add New Pathogen Isolates Log",
-                "List Pathogen Isolates Logs",
-                "Add New Supranational Ref",
-                "List Supranational Refs",
-                "Delete",
-            ];
+            return PrevalenceCaseReportFormOptions(hasReadAccess, hasCaptureAccess);
         case "PrevalenceSampleShipTrackForm":
         case "PrevalenceCentralRefLabForm":
         case "PrevalencePathogenIsolatesLog":
         case "PrevalenceSupranationalRefLabForm":
         case "PPSPatientRegister":
         default:
-            return ["Edit", "Delete"];
+            return DefaultFormOptions(hasReadAccess, hasCaptureAccess);
     }
 };
 
@@ -206,10 +210,12 @@ export const getParentOUIdFromPath = (path: string | undefined) => {
 export const hideCreateNewButton = (
     surveyFormType: SURVEY_FORM_TYPES,
     isAdmin: boolean,
+    hasReadAccess: boolean,
     currentPPSFormType: string,
     surveys: Survey[] | undefined
 ): boolean => {
     return (
+        hasReadAccess ||
         (surveyFormType === "PPSHospitalForm" && !isAdmin) ||
         // For PPS Survey Forms of National Type, only one child survey(country) should be allowed.
         (surveyFormType === "PPSCountryQuestionnaire" &&

--- a/src/domain/utils/optionsHelper.ts
+++ b/src/domain/utils/optionsHelper.ts
@@ -5,14 +5,7 @@ export type OptionType = {
 
 export const PPSSurveyNationalOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
     return [
-        {
-            label: "Edit",
-            isHidden: hasReadAccess,
-        },
-        {
-            label: "View",
-            isHidden: hasCaptureAccess,
-        },
+        ...DefaultFormOptions(hasReadAccess, hasCaptureAccess),
         {
             label: "Add New Country",
             isHidden: hasReadAccess,
@@ -20,23 +13,12 @@ export const PPSSurveyNationalOptions = (hasReadAccess: boolean, hasCaptureAcces
         {
             label: "List Country",
         },
-        {
-            label: "Delete",
-            isHidden: hasReadAccess,
-        },
     ];
 };
 
 export const PPSSurveyHospitalOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
     return [
-        {
-            label: "Edit",
-            isHidden: hasReadAccess,
-        },
-        {
-            label: "View",
-            isHidden: hasCaptureAccess,
-        },
+        ...DefaultFormOptions(hasReadAccess, hasCaptureAccess),
         {
             label: "Add New Hospital",
             isHidden: hasReadAccess,
@@ -44,23 +26,12 @@ export const PPSSurveyHospitalOptions = (hasReadAccess: boolean, hasCaptureAcces
         {
             label: "List Hospitals",
         },
-        {
-            label: "Delete",
-            isHidden: hasReadAccess,
-        },
     ];
 };
 
 export const PPSSurveyDefaultOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
     return [
-        {
-            label: "Edit",
-            isHidden: hasReadAccess,
-        },
-        {
-            label: "View",
-            isHidden: hasCaptureAccess,
-        },
+        ...DefaultFormOptions(hasReadAccess, hasCaptureAccess),
         {
             label: "Add New Country",
             isHidden: hasReadAccess,
@@ -68,23 +39,11 @@ export const PPSSurveyDefaultOptions = (hasReadAccess: boolean, hasCaptureAccess
         {
             label: "List Countries",
         },
-        {
-            label: "Delete",
-            isHidden: hasReadAccess,
-        },
     ];
 };
 
 export const PPSCountryFormOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
     return [
-        {
-            label: "Edit",
-            isHidden: hasReadAccess,
-        },
-        {
-            label: "View",
-            isHidden: hasCaptureAccess,
-        },
         {
             label: "Add New Hospital",
             isHidden: hasReadAccess,
@@ -92,23 +51,13 @@ export const PPSCountryFormOptions = (hasReadAccess: boolean, hasCaptureAccess: 
         {
             label: "List Hospitals",
         },
-        {
-            label: "Delete",
-            isHidden: hasReadAccess,
-        },
+        ...DefaultFormOptions(hasReadAccess, hasCaptureAccess),
     ];
 };
 
 export const PPSHospitalFormOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
     return [
-        {
-            label: "Edit",
-            isHidden: hasReadAccess,
-        },
-        {
-            label: "View",
-            isHidden: hasCaptureAccess,
-        },
+        ...DefaultFormOptions(hasReadAccess, hasCaptureAccess),
         {
             label: "Add New Ward",
             isHidden: hasReadAccess,
@@ -116,23 +65,12 @@ export const PPSHospitalFormOptions = (hasReadAccess: boolean, hasCaptureAccess:
         {
             label: "List Wards",
         },
-        {
-            label: "Delete",
-            isHidden: hasReadAccess,
-        },
     ];
 };
 
 export const PPSWardFormOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
     return [
-        {
-            label: "Edit",
-            isHidden: hasReadAccess,
-        },
-        {
-            label: "View",
-            isHidden: hasCaptureAccess,
-        },
+        ...DefaultFormOptions(hasReadAccess, hasCaptureAccess),
         {
             label: "Add New Patient",
             isHidden: hasReadAccess,
@@ -140,33 +78,18 @@ export const PPSWardFormOptions = (hasReadAccess: boolean, hasCaptureAccess: boo
         {
             label: "List Patients",
         },
-        {
-            label: "Delete",
-            isHidden: hasReadAccess,
-        },
     ];
 };
 
 export const PrevalenceSurveyFormOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
     return [
-        {
-            label: "Edit",
-            isHidden: hasReadAccess,
-        },
-        {
-            label: "View",
-            isHidden: hasCaptureAccess,
-        },
+        ...DefaultFormOptions(hasReadAccess, hasCaptureAccess),
         {
             label: "Add New Facility",
             isHidden: hasReadAccess,
         },
         {
             label: "List Facilities",
-        },
-        {
-            label: "Delete",
-            isHidden: hasReadAccess,
         },
     ];
 };
@@ -176,24 +99,13 @@ export const PrevalenceFacilityLevelFormOptions = (
     hasCaptureAccess: boolean
 ) => {
     return [
-        {
-            label: "Edit",
-            isHidden: hasReadAccess,
-        },
-        {
-            label: "View",
-            isHidden: hasCaptureAccess,
-        },
+        ...DefaultFormOptions(hasReadAccess, hasCaptureAccess),
         {
             label: "Add New Patient",
             isHidden: hasReadAccess,
         },
         {
             label: "List Patients",
-        },
-        {
-            label: "Delete",
-            isHidden: hasReadAccess,
         },
     ];
 };
@@ -203,14 +115,7 @@ export const PrevalenceCaseReportFormOptions = (
     hasCaptureAccess: boolean
 ) => {
     return [
-        {
-            label: "Edit",
-            isHidden: hasReadAccess,
-        },
-        {
-            label: "View",
-            isHidden: hasCaptureAccess,
-        },
+        ...DefaultFormOptions(hasReadAccess, hasCaptureAccess),
         {
             label: "Add New Sample Shipment",
             isHidden: hasReadAccess,
@@ -238,10 +143,6 @@ export const PrevalenceCaseReportFormOptions = (
         },
         {
             label: "List Supranational Refs Results",
-        },
-        {
-            label: "Delete",
-            isHidden: hasReadAccess,
         },
     ];
 };

--- a/src/domain/utils/optionsHelper.ts
+++ b/src/domain/utils/optionsHelper.ts
@@ -1,0 +1,256 @@
+export type OptionType = {
+    label: string;
+    isHidden?: boolean;
+};
+
+export const PPSSurveyNationalOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
+    return [
+        {
+            label: "Edit",
+            isHidden: hasReadAccess,
+        },
+        {
+            label: "View",
+            isHidden: hasCaptureAccess,
+        },
+        {
+            label: "Add New Country",
+        },
+        {
+            label: "List Country",
+        },
+        {
+            label: "Delete",
+            isHidden: hasReadAccess,
+        },
+    ];
+};
+
+export const PPSSurveyHospitalOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
+    return [
+        {
+            label: "Edit",
+            isHidden: hasReadAccess,
+        },
+        {
+            label: "View",
+            isHidden: hasCaptureAccess,
+        },
+        {
+            label: "Add New Hospital",
+        },
+        {
+            label: "List Hospitals",
+        },
+        {
+            label: "Delete",
+            isHidden: hasReadAccess,
+        },
+    ];
+};
+
+export const PPSSurveyDefaultOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
+    return [
+        {
+            label: "Edit",
+            isHidden: hasReadAccess,
+        },
+        {
+            label: "View",
+            isHidden: hasCaptureAccess,
+        },
+        {
+            label: "Add New Country",
+        },
+        {
+            label: "List Countries",
+        },
+        {
+            label: "Delete",
+            isHidden: hasReadAccess,
+        },
+    ];
+};
+
+export const PPSCountryFormOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
+    return [
+        {
+            label: "Edit",
+            isHidden: hasReadAccess,
+        },
+        {
+            label: "View",
+            isHidden: hasCaptureAccess,
+        },
+        {
+            label: "Add New Hospital",
+        },
+        {
+            label: "List Hospitals",
+        },
+        {
+            label: "Delete",
+            isHidden: hasReadAccess,
+        },
+    ];
+};
+
+export const PPSHospitalFormOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
+    return [
+        {
+            label: "Edit",
+            isHidden: hasReadAccess,
+        },
+        {
+            label: "View",
+            isHidden: hasCaptureAccess,
+        },
+        {
+            label: "Add New Ward",
+        },
+        {
+            label: "List Wards",
+        },
+        {
+            label: "Delete",
+            isHidden: hasReadAccess,
+        },
+    ];
+};
+
+export const PPSWardFormOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
+    return [
+        {
+            label: "Edit",
+            isHidden: hasReadAccess,
+        },
+        {
+            label: "View",
+            isHidden: hasCaptureAccess,
+        },
+        {
+            label: "Add New Patient",
+        },
+        {
+            label: "List Patients",
+        },
+        {
+            label: "Delete",
+            isHidden: hasReadAccess,
+        },
+    ];
+};
+
+export const PrevalenceSurveyFormOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
+    return [
+        {
+            label: "Edit",
+            isHidden: hasReadAccess,
+        },
+        {
+            label: "View",
+            isHidden: hasCaptureAccess,
+        },
+        {
+            label: "Add New Facility",
+        },
+        {
+            label: "List Facilities",
+        },
+        {
+            label: "Delete",
+            isHidden: hasReadAccess,
+        },
+    ];
+};
+
+export const PrevalenceFacilityLevelFormOptions = (
+    hasReadAccess: boolean,
+    hasCaptureAccess: boolean
+) => {
+    return [
+        {
+            label: "Edit",
+            isHidden: hasReadAccess,
+        },
+        {
+            label: "View",
+            isHidden: hasCaptureAccess,
+        },
+        {
+            label: "Add New Patient",
+        },
+        {
+            label: "List Patients",
+        },
+        {
+            label: "Delete",
+            isHidden: hasReadAccess,
+        },
+    ];
+};
+
+export const PrevalenceCaseReportFormOptions = (
+    hasReadAccess: boolean,
+    hasCaptureAccess: boolean
+) => {
+    return [
+        {
+            label: "Edit",
+            isHidden: hasReadAccess,
+        },
+        {
+            label: "View",
+            isHidden: hasCaptureAccess,
+        },
+        {
+            label: "Add New Sample Shipment",
+            isHidden: hasReadAccess,
+        },
+        {
+            label: "List Sample Shipments",
+        },
+        {
+            label: "Add New Central Ref Lab",
+            isHidden: hasReadAccess,
+        },
+        {
+            label: "List Central Ref Labs",
+        },
+        {
+            label: "Add New Pathogen Isolates Log",
+            isHidden: hasReadAccess,
+        },
+        {
+            label: "List Pathogen Isolates Logs",
+        },
+        {
+            label: "Add New Supranational Ref",
+            isHidden: hasReadAccess,
+        },
+        {
+            label: "List Supranational Refs",
+        },
+        {
+            label: "Delete",
+            isHidden: hasReadAccess,
+        },
+    ];
+};
+
+export const DefaultFormOptions = (hasReadAccess: boolean, hasCaptureAccess: boolean) => {
+    return [
+        {
+            label: "Edit",
+            isHidden: hasReadAccess,
+        },
+        {
+            label: "View",
+            isHidden: hasCaptureAccess,
+        },
+        {
+            label: "Delete",
+            isHidden: hasReadAccess,
+        },
+    ];
+};

--- a/src/domain/utils/optionsHelper.ts
+++ b/src/domain/utils/optionsHelper.ts
@@ -219,11 +219,11 @@ export const PrevalenceCaseReportFormOptions = (
             label: "List Sample Shipments",
         },
         {
-            label: "Add New Central Ref Lab",
+            label: "Add New Central Ref Lab Results",
             isHidden: hasReadAccess,
         },
         {
-            label: "List Central Ref Labs",
+            label: "List Central Ref Labs Results",
         },
         {
             label: "Add New Pathogen Isolates Log",
@@ -233,11 +233,11 @@ export const PrevalenceCaseReportFormOptions = (
             label: "List Pathogen Isolates Logs",
         },
         {
-            label: "Add New Supranational Ref",
+            label: "Add New Supranational Ref Results",
             isHidden: hasReadAccess,
         },
         {
-            label: "List Supranational Refs",
+            label: "List Supranational Refs Results",
         },
         {
             label: "Delete",

--- a/src/domain/utils/optionsHelper.ts
+++ b/src/domain/utils/optionsHelper.ts
@@ -15,6 +15,7 @@ export const PPSSurveyNationalOptions = (hasReadAccess: boolean, hasCaptureAcces
         },
         {
             label: "Add New Country",
+            isHidden: hasReadAccess,
         },
         {
             label: "List Country",
@@ -38,6 +39,7 @@ export const PPSSurveyHospitalOptions = (hasReadAccess: boolean, hasCaptureAcces
         },
         {
             label: "Add New Hospital",
+            isHidden: hasReadAccess,
         },
         {
             label: "List Hospitals",
@@ -61,6 +63,7 @@ export const PPSSurveyDefaultOptions = (hasReadAccess: boolean, hasCaptureAccess
         },
         {
             label: "Add New Country",
+            isHidden: hasReadAccess,
         },
         {
             label: "List Countries",
@@ -84,6 +87,7 @@ export const PPSCountryFormOptions = (hasReadAccess: boolean, hasCaptureAccess: 
         },
         {
             label: "Add New Hospital",
+            isHidden: hasReadAccess,
         },
         {
             label: "List Hospitals",
@@ -107,6 +111,7 @@ export const PPSHospitalFormOptions = (hasReadAccess: boolean, hasCaptureAccess:
         },
         {
             label: "Add New Ward",
+            isHidden: hasReadAccess,
         },
         {
             label: "List Wards",
@@ -130,6 +135,7 @@ export const PPSWardFormOptions = (hasReadAccess: boolean, hasCaptureAccess: boo
         },
         {
             label: "Add New Patient",
+            isHidden: hasReadAccess,
         },
         {
             label: "List Patients",
@@ -153,6 +159,7 @@ export const PrevalenceSurveyFormOptions = (hasReadAccess: boolean, hasCaptureAc
         },
         {
             label: "Add New Facility",
+            isHidden: hasReadAccess,
         },
         {
             label: "List Facilities",
@@ -179,6 +186,7 @@ export const PrevalenceFacilityLevelFormOptions = (
         },
         {
             label: "Add New Patient",
+            isHidden: hasReadAccess,
         },
         {
             label: "List Patients",

--- a/src/webapp/components/action-menu-button/ActionMenuButton.tsx
+++ b/src/webapp/components/action-menu-button/ActionMenuButton.tsx
@@ -2,9 +2,10 @@ import { IconButton, Menu, MenuItem } from "@material-ui/core";
 import MoreVert from "@material-ui/icons/MoreVert";
 import * as React from "react";
 import styled from "styled-components";
+import { OptionType } from "../../../domain/utils/optionsHelper";
 
 interface ActionMenuProps {
-    options: string[];
+    options: OptionType[];
     optionClickHandler: { option: string; handler: (option?: string) => void }[];
     onClickHandler: () => void;
 }
@@ -49,11 +50,13 @@ export const ActionMenuButton: React.FC<ActionMenuProps> = ({
                 open={open}
                 onClose={handleClose}
             >
-                {options.map(option => (
-                    <MenuItem key={option} onClick={() => menuItemClick(option)}>
-                        {option}
-                    </MenuItem>
-                ))}
+                {options
+                    .filter(option => !option.isHidden)
+                    .map(option => (
+                        <MenuItem key={option.label} onClick={() => menuItemClick(option.label)}>
+                            {option.label}
+                        </MenuItem>
+                    ))}
             </Menu>
         </div>
     );

--- a/src/webapp/components/survey-list/SurveyList.tsx
+++ b/src/webapp/components/survey-list/SurveyList.tsx
@@ -22,6 +22,7 @@ import _ from "../../../domain/entities/generic/Collection";
 import { useFilteredSurveys } from "./hook/useFilteredSurveys";
 import { PaginatedSurveyListTable } from "./table/PaginatedSurveyListTable";
 import { usePatientSearch } from "./hook/usePatientSearch";
+import useReadAccess from "../survey/hook/useReadAccess";
 
 interface SurveyListProps {
     surveyFormType: SURVEY_FORM_TYPES;
@@ -30,6 +31,7 @@ export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
     const { currentPPSSurveyForm } = useCurrentSurveys();
     const { currentUser } = useAppContext();
     const { currentModule } = useCurrentModule();
+    const { hasReadAccess } = useReadAccess();
 
     const isAdmin = currentModule
         ? getUserAccess(currentModule, currentUser.userGroups).hasAdminAccess
@@ -73,6 +75,7 @@ export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
                         {!hideCreateNewButton(
                             surveyFormType,
                             isAdmin,
+                            hasReadAccess,
                             currentPPSSurveyForm?.surveyType
                                 ? currentPPSSurveyForm?.surveyType
                                 : "",

--- a/src/webapp/components/survey-list/SurveyList.tsx
+++ b/src/webapp/components/survey-list/SurveyList.tsx
@@ -22,7 +22,7 @@ import _ from "../../../domain/entities/generic/Collection";
 import { useFilteredSurveys } from "./hook/useFilteredSurveys";
 import { PaginatedSurveyListTable } from "./table/PaginatedSurveyListTable";
 import { usePatientSearch } from "./hook/usePatientSearch";
-import useReadAccess from "../survey/hook/useReadAccess";
+import useReadOnlyAccess from "../survey/hook/useReadOnlyAccess";
 
 interface SurveyListProps {
     surveyFormType: SURVEY_FORM_TYPES;
@@ -31,7 +31,7 @@ export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
     const { currentPPSSurveyForm } = useCurrentSurveys();
     const { currentUser } = useAppContext();
     const { currentModule } = useCurrentModule();
-    const { hasReadAccess } = useReadAccess();
+    const { hasReadOnlyAccess } = useReadOnlyAccess();
 
     const isAdmin = currentModule
         ? getUserAccess(currentModule, currentUser.userGroups).hasAdminAccess
@@ -75,7 +75,7 @@ export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
                         {!hideCreateNewButton(
                             surveyFormType,
                             isAdmin,
-                            hasReadAccess,
+                            hasReadOnlyAccess,
                             currentPPSSurveyForm?.surveyType
                                 ? currentPPSSurveyForm?.surveyType
                                 : "",

--- a/src/webapp/components/survey-list/hook/useSurveyListActions.ts
+++ b/src/webapp/components/survey-list/hook/useSurveyListActions.ts
@@ -9,7 +9,7 @@ import { useCurrentModule } from "../../../contexts/current-module-context";
 import { getUserAccess } from "../../../../domain/utils/menuHelper";
 import { useAppContext } from "../../../contexts/app-context";
 import { OptionType } from "../../../../domain/utils/optionsHelper";
-import useReadAccess from "../../survey/hook/useReadAccess";
+import useReadOnlyAccess from "../../survey/hook/useReadOnlyAccess";
 import useCaptureAccess from "../../survey/hook/useCaptureAccess";
 
 export type SortDirection = "asc" | "desc";
@@ -31,7 +31,7 @@ export function useSurveyListActions(surveyFormType: SURVEY_FORM_TYPES) {
     } = useCurrentSurveys();
     const { currentModule } = useCurrentModule();
     const { currentUser } = useAppContext();
-    const { hasReadAccess } = useReadAccess();
+    const { hasReadOnlyAccess } = useReadOnlyAccess();
     const { hasCaptureAccess } = useCaptureAccess();
 
     const isAdmin = currentModule
@@ -97,7 +97,7 @@ export function useSurveyListActions(surveyFormType: SURVEY_FORM_TYPES) {
         setOptionLoading(true);
         const currentOptions = getSurveyOptions(
             surveyFormType,
-            hasReadAccess,
+            hasReadOnlyAccess,
             hasCaptureAccess,
             ppsSurveyType
         );

--- a/src/webapp/components/survey-list/hook/useSurveyListActions.ts
+++ b/src/webapp/components/survey-list/hook/useSurveyListActions.ts
@@ -8,12 +8,15 @@ import { useCurrentSurveys } from "../../../contexts/current-surveys-context";
 import { useCurrentModule } from "../../../contexts/current-module-context";
 import { getUserAccess } from "../../../../domain/utils/menuHelper";
 import { useAppContext } from "../../../contexts/app-context";
+import { OptionType } from "../../../../domain/utils/optionsHelper";
+import useReadAccess from "../../survey/hook/useReadAccess";
+import useCaptureAccess from "../../survey/hook/useCaptureAccess";
 
 export type SortDirection = "asc" | "desc";
 export function useSurveyListActions(surveyFormType: SURVEY_FORM_TYPES) {
     const { compositionRoot } = useAppContext();
     const history = useHistory();
-    const [options, setOptions] = useState<string[]>([]);
+    const [options, setOptions] = useState<OptionType[]>([]);
     const [sortedSurveys, setSortedSurveys] = useState<Survey[]>();
     const [optionLoading, setOptionLoading] = useState<boolean>(false);
 
@@ -28,12 +31,14 @@ export function useSurveyListActions(surveyFormType: SURVEY_FORM_TYPES) {
     } = useCurrentSurveys();
     const { currentModule } = useCurrentModule();
     const { currentUser } = useAppContext();
+    const { hasReadAccess } = useReadAccess();
+    const { hasCaptureAccess } = useCaptureAccess();
 
     const isAdmin = currentModule
         ? getUserAccess(currentModule, currentUser.userGroups).hasAdminAccess
         : false;
 
-    const editSurvey = (survey: Survey) => {
+    const goToSurvey = (survey: Survey) => {
         updateSelectedSurveyDetails(
             {
                 id: survey.id,
@@ -90,8 +95,12 @@ export function useSurveyListActions(surveyFormType: SURVEY_FORM_TYPES) {
 
     const actionClick = (ppsSurveyType: string, survey?: Survey) => {
         setOptionLoading(true);
-        const currentOptions = getSurveyOptions(surveyFormType, ppsSurveyType);
-
+        const currentOptions = getSurveyOptions(
+            surveyFormType,
+            hasReadAccess,
+            hasCaptureAccess,
+            ppsSurveyType
+        );
         if (!survey) {
             setOptions(currentOptions);
             setOptionLoading(false);
@@ -109,9 +118,9 @@ export function useSurveyListActions(surveyFormType: SURVEY_FORM_TYPES) {
                 childCountMap => {
                     if (typeof childCountMap === "number") {
                         const optionsWithChildCount = currentOptions.map(option => {
-                            if (option.startsWith("List")) {
-                                const updatedOption = `${option} (${childCountMap})`;
-                                return updatedOption;
+                            if (option.label.startsWith("List")) {
+                                const updatedLabel = `${option.label} (${childCountMap})`;
+                                return { ...option, label: updatedLabel };
                             }
                             return option;
                         });
@@ -121,7 +130,7 @@ export function useSurveyListActions(surveyFormType: SURVEY_FORM_TYPES) {
                     } else {
                         const optionsWithChildCount = currentOptions.map(option => {
                             const updatedChilsOptionMap = childCountMap.find(childMap =>
-                                childMap.option.startsWith(option)
+                                childMap.option.label.startsWith(option.label)
                             );
                             if (updatedChilsOptionMap) {
                                 return updatedChilsOptionMap.option;
@@ -182,7 +191,7 @@ export function useSurveyListActions(surveyFormType: SURVEY_FORM_TYPES) {
         sortedSurveys,
         optionLoading,
         setSortedSurveys,
-        editSurvey,
+        goToSurvey,
         assignChild,
         listChildren,
         actionClick,

--- a/src/webapp/components/survey-list/table/PaginatedSurveyListTable.tsx
+++ b/src/webapp/components/survey-list/table/PaginatedSurveyListTable.tsx
@@ -58,7 +58,7 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
         optionLoading,
         sortedSurveys,
         setSortedSurveys,
-        editSurvey,
+        goToSurvey,
         assignChild,
         listChildren,
         actionClick,
@@ -170,13 +170,17 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                                                     }
                                                     options={
                                                         optionLoading
-                                                            ? [i18n.t("Loading...")]
+                                                            ? [{ label: i18n.t("Loading...") }]
                                                             : options
                                                     }
                                                     optionClickHandler={[
                                                         {
                                                             option: "Edit",
-                                                            handler: () => editSurvey(survey),
+                                                            handler: () => goToSurvey(survey),
+                                                        },
+                                                        {
+                                                            option: "View",
+                                                            handler: () => goToSurvey(survey),
                                                         },
                                                         {
                                                             option: "Delete",
@@ -189,40 +193,40 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                                                         {
                                                             option:
                                                                 options.find(op =>
-                                                                    op.startsWith(
+                                                                    op.label.startsWith(
                                                                         "Add New Sample Shipment"
                                                                     )
-                                                                ) ?? "",
+                                                                )?.label ?? "",
                                                             handler: option =>
                                                                 assignChild(survey, option),
                                                         },
                                                         {
                                                             option:
                                                                 options.find(op =>
-                                                                    op.startsWith(
+                                                                    op.label.startsWith(
                                                                         "List Sample Shipments"
                                                                     )
-                                                                ) ?? "",
+                                                                )?.label ?? "",
                                                             handler: option =>
                                                                 listChildren(survey, option),
                                                         },
                                                         {
                                                             option:
                                                                 options.find(op =>
-                                                                    op.startsWith(
+                                                                    op.label.startsWith(
                                                                         "Add New Central Ref Lab"
                                                                     )
-                                                                ) ?? "",
+                                                                )?.label ?? "",
                                                             handler: option =>
                                                                 assignChild(survey, option),
                                                         },
                                                         {
                                                             option:
                                                                 options.find(op =>
-                                                                    op.startsWith(
+                                                                    op.label.startsWith(
                                                                         "List Central Ref Labs"
                                                                     )
-                                                                ) ?? "",
+                                                                )?.label ?? "",
                                                             handler: option =>
                                                                 listChildren(survey, option),
                                                         },
@@ -230,40 +234,40 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                                                         {
                                                             option:
                                                                 options.find(op =>
-                                                                    op.startsWith(
+                                                                    op.label.startsWith(
                                                                         "Add New Pathogen Isolates Log"
                                                                     )
-                                                                ) ?? "",
+                                                                )?.label ?? "",
                                                             handler: option =>
                                                                 assignChild(survey, option),
                                                         },
                                                         {
                                                             option:
                                                                 options.find(op =>
-                                                                    op.startsWith(
+                                                                    op.label.startsWith(
                                                                         "List Pathogen Isolates Logs"
                                                                     )
-                                                                ) ?? "",
+                                                                )?.label ?? "",
                                                             handler: option =>
                                                                 listChildren(survey, option),
                                                         },
                                                         {
                                                             option:
                                                                 options.find(op =>
-                                                                    op.startsWith(
+                                                                    op.label.startsWith(
                                                                         "Add New Supranational Ref"
                                                                     )
-                                                                ) ?? "",
+                                                                )?.label ?? "",
                                                             handler: option =>
                                                                 assignChild(survey, option),
                                                         },
                                                         {
                                                             option:
                                                                 options.find(op =>
-                                                                    op.startsWith(
+                                                                    op.label.startsWith(
                                                                         "List Supranational Refs"
                                                                     )
-                                                                ) ?? "",
+                                                                )?.label ?? "",
                                                             handler: option =>
                                                                 listChildren(survey, option),
                                                         },

--- a/src/webapp/components/survey-list/table/SurveyListTable.tsx
+++ b/src/webapp/components/survey-list/table/SurveyListTable.tsx
@@ -53,7 +53,7 @@ export const SurveyListTable: React.FC<SurveyListTableProps> = ({
         optionLoading,
         sortedSurveys,
         setSortedSurveys,
-        editSurvey,
+        goToSurvey,
         assignChild,
         listChildren,
         actionClick,
@@ -269,13 +269,17 @@ export const SurveyListTable: React.FC<SurveyListTableProps> = ({
                                                         }
                                                         options={
                                                             optionLoading
-                                                                ? [i18n.t("Loading...")]
+                                                                ? [{ label: i18n.t("Loading...") }]
                                                                 : options
                                                         }
                                                         optionClickHandler={[
                                                             {
                                                                 option: "Edit",
-                                                                handler: () => editSurvey(survey),
+                                                                handler: () => goToSurvey(survey),
+                                                            },
+                                                            {
+                                                                option: "View",
+                                                                handler: () => goToSurvey(survey),
                                                             },
                                                             {
                                                                 option: "Delete",
@@ -285,15 +289,19 @@ export const SurveyListTable: React.FC<SurveyListTableProps> = ({
                                                             {
                                                                 option:
                                                                     options.find(option =>
-                                                                        option.startsWith("Add")
-                                                                    ) || "",
+                                                                        option.label.startsWith(
+                                                                            "Add"
+                                                                        )
+                                                                    )?.label || "",
                                                                 handler: () => assignChild(survey),
                                                             },
                                                             {
                                                                 option:
                                                                     options.find(option =>
-                                                                        option.startsWith("List")
-                                                                    ) || "",
+                                                                        option.label.startsWith(
+                                                                            "List"
+                                                                        )
+                                                                    )?.label || "",
                                                                 handler: () => listChildren(survey),
                                                             },
                                                         ]}

--- a/src/webapp/components/survey/SurveyForm.tsx
+++ b/src/webapp/components/survey/SurveyForm.tsx
@@ -15,6 +15,7 @@ import { SurveySection } from "./SurveySection";
 import { useHistory } from "react-router-dom";
 import { Question } from "../../../domain/entities/Questionnaire/QuestionnaireQuestion";
 import { Questionnaire } from "../../../domain/entities/Questionnaire/Questionnaire";
+import useReadAccess from "./hook/useReadAccess";
 
 export interface SurveyFormProps {
     hideForm: () => void;
@@ -36,6 +37,7 @@ const CancelButton = withStyles(() => ({
 export const SurveyForm: React.FC<SurveyFormProps> = props => {
     const snackbar = useSnackbar();
     const history = useHistory();
+    const { hasReadAccess } = useReadAccess();
 
     const {
         questionnaire,
@@ -106,6 +108,7 @@ export const SurveyForm: React.FC<SurveyFormProps> = props => {
                         title={questionnaire.entity.title}
                         updateQuestion={updateQuestion}
                         questions={questionnaire.entity.questions}
+                        viewOnly={hasReadAccess}
                     />
                 )}
                 {questionnaire?.stages?.map(stage => {
@@ -124,6 +127,7 @@ export const SurveyForm: React.FC<SurveyFormProps> = props => {
                                         updateQuestion={updateQuestion}
                                         questions={section.questions}
                                         showAddnew={section.showAddnew}
+                                        viewOnly={hasReadAccess}
                                     />
                                 );
                             })}

--- a/src/webapp/components/survey/SurveyForm.tsx
+++ b/src/webapp/components/survey/SurveyForm.tsx
@@ -15,7 +15,7 @@ import { SurveySection } from "./SurveySection";
 import { useHistory } from "react-router-dom";
 import { Question } from "../../../domain/entities/Questionnaire/QuestionnaireQuestion";
 import { Questionnaire } from "../../../domain/entities/Questionnaire/Questionnaire";
-import useReadAccess from "./hook/useReadAccess";
+import useReadOnlyAccess from "./hook/useReadOnlyAccess";
 
 export interface SurveyFormProps {
     hideForm: () => void;
@@ -37,7 +37,7 @@ const CancelButton = withStyles(() => ({
 export const SurveyForm: React.FC<SurveyFormProps> = props => {
     const snackbar = useSnackbar();
     const history = useHistory();
-    const { hasReadAccess } = useReadAccess();
+    const { hasReadOnlyAccess } = useReadOnlyAccess();
 
     const {
         questionnaire,
@@ -108,7 +108,7 @@ export const SurveyForm: React.FC<SurveyFormProps> = props => {
                         title={questionnaire.entity.title}
                         updateQuestion={updateQuestion}
                         questions={questionnaire.entity.questions}
-                        viewOnly={hasReadAccess}
+                        viewOnly={hasReadOnlyAccess}
                     />
                 )}
                 {questionnaire?.stages?.map(stage => {
@@ -127,7 +127,7 @@ export const SurveyForm: React.FC<SurveyFormProps> = props => {
                                         updateQuestion={updateQuestion}
                                         questions={section.questions}
                                         showAddnew={section.showAddnew}
-                                        viewOnly={hasReadAccess}
+                                        viewOnly={hasReadOnlyAccess}
                                     />
                                 );
                             })}

--- a/src/webapp/components/survey/SurveySection.tsx
+++ b/src/webapp/components/survey/SurveySection.tsx
@@ -27,6 +27,7 @@ interface SurveySectionProps {
     showAddnew?: boolean;
     showAddQuestion?: string;
     addNewClick?: () => void;
+    viewOnly?: boolean;
 }
 export const SurveySection: React.FC<SurveySectionProps> = ({
     title,
@@ -35,6 +36,7 @@ export const SurveySection: React.FC<SurveySectionProps> = ({
     showAddnew,
     showAddQuestion,
     addNewClick,
+    viewOnly,
 }) => {
     return (
         <StyledSection key={title}>
@@ -62,7 +64,9 @@ export const SurveySection: React.FC<SurveySectionProps> = ({
                                             <QuestionWidget
                                                 onChange={updateQuestion}
                                                 question={question}
-                                                disabled={question.disabled ? true : false}
+                                                disabled={
+                                                    question.disabled || viewOnly ? true : false
+                                                }
                                             />
                                             {question.errors.map((err, index) => (
                                                 <PaddedDiv key={index}>

--- a/src/webapp/components/survey/hook/useCaptureAccess.ts
+++ b/src/webapp/components/survey/hook/useCaptureAccess.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react";
+import { useAppContext } from "../../../contexts/app-context";
+import { useCurrentModule } from "../../../contexts/current-module-context";
+import { getUserAccess } from "../../../../domain/utils/menuHelper";
+
+const useCaptureAccess = () => {
+    const { currentUser } = useAppContext();
+    const { currentModule } = useCurrentModule();
+    const [hasCaptureAccess, setHasCaptureAccess] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (currentModule) {
+            const { hasCaptureAccess, hasAdminAccess } = getUserAccess(
+                currentModule,
+                currentUser.userGroups
+            );
+
+            setHasCaptureAccess(hasCaptureAccess || hasAdminAccess);
+        }
+    }, [currentModule, currentUser]);
+
+    return { hasCaptureAccess };
+};
+
+export default useCaptureAccess;

--- a/src/webapp/components/survey/hook/useReadAccess.ts
+++ b/src/webapp/components/survey/hook/useReadAccess.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from "react";
+import { useAppContext } from "../../../contexts/app-context";
+import { useCurrentModule } from "../../../contexts/current-module-context";
+import { getUserAccess } from "../../../../domain/utils/menuHelper";
+
+const useReadAccess = () => {
+    const { currentUser } = useAppContext();
+    const { currentModule } = useCurrentModule();
+    const [hasReadAccess, setHasReadAccess] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (currentModule) {
+            const { hasReadAccess } = getUserAccess(currentModule, currentUser.userGroups);
+            setHasReadAccess(hasReadAccess);
+        }
+    }, [currentModule, currentUser.userGroups]);
+
+    return { hasReadAccess };
+};
+
+export default useReadAccess;

--- a/src/webapp/components/survey/hook/useReadAccess.ts
+++ b/src/webapp/components/survey/hook/useReadAccess.ts
@@ -10,8 +10,11 @@ const useReadAccess = () => {
 
     useEffect(() => {
         if (currentModule) {
-            const { hasReadAccess } = getUserAccess(currentModule, currentUser.userGroups);
-            setHasReadAccess(hasReadAccess);
+            const { hasReadAccess, hasCaptureAccess, hasAdminAccess } = getUserAccess(
+                currentModule,
+                currentUser.userGroups
+            );
+            setHasReadAccess(hasReadAccess && !hasCaptureAccess && !hasAdminAccess);
         }
     }, [currentModule, currentUser.userGroups]);
 

--- a/src/webapp/components/survey/hook/useReadOnlyAccess.ts
+++ b/src/webapp/components/survey/hook/useReadOnlyAccess.ts
@@ -3,10 +3,10 @@ import { useAppContext } from "../../../contexts/app-context";
 import { useCurrentModule } from "../../../contexts/current-module-context";
 import { getUserAccess } from "../../../../domain/utils/menuHelper";
 
-const useReadAccess = () => {
+const useReadOnlyAccess = () => {
     const { currentUser } = useAppContext();
     const { currentModule } = useCurrentModule();
-    const [hasReadAccess, setHasReadAccess] = useState<boolean>(false);
+    const [hasReadOnlyAccess, setHasReadOnlyAccess] = useState<boolean>(false);
 
     useEffect(() => {
         if (currentModule) {
@@ -14,11 +14,11 @@ const useReadAccess = () => {
                 currentModule,
                 currentUser.userGroups
             );
-            setHasReadAccess(hasReadAccess && !hasCaptureAccess && !hasAdminAccess);
+            setHasReadOnlyAccess(hasReadAccess && !hasCaptureAccess && !hasAdminAccess);
         }
     }, [currentModule, currentUser.userGroups]);
 
-    return { hasReadAccess };
+    return { hasReadOnlyAccess };
 };
 
-export default useReadAccess;
+export default useReadOnlyAccess;

--- a/src/webapp/components/survey/hook/useSurveyForm.ts
+++ b/src/webapp/components/survey/hook/useSurveyForm.ts
@@ -5,7 +5,7 @@ import { SURVEY_FORM_TYPES } from "../../../../domain/entities/Survey";
 import { OrgUnitAccess } from "../../../../domain/entities/User";
 import { useCurrentSurveys } from "../../../contexts/current-surveys-context";
 import { useHospitalContext } from "../../../contexts/hospital-context";
-import useReadAccess from "./useReadAccess";
+import useReadOnlyAccess from "./useReadOnlyAccess";
 
 export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | undefined) {
     const { compositionRoot, currentUser } = useAppContext();
@@ -21,7 +21,7 @@ export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | und
         currentPrevalenceSurveyForm,
         currentFacilityLevelForm,
     } = useCurrentSurveys();
-    const { hasReadAccess } = useReadAccess();
+    const { hasReadOnlyAccess } = useReadOnlyAccess();
 
     const [error, setError] = useState<string>();
 
@@ -29,9 +29,9 @@ export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | und
         if (!questionnaire) setShouldDisableSave(true);
         else {
             const shouldDisable = Questionnaire.doesQuestionnaireHaveErrors(questionnaire);
-            setShouldDisableSave(shouldDisable || hasReadAccess);
+            setShouldDisableSave(shouldDisable || hasReadOnlyAccess);
         }
-    }, [hasReadAccess, questionnaire]);
+    }, [hasReadOnlyAccess, questionnaire]);
 
     useEffect(() => {
         setLoading(true);

--- a/src/webapp/components/survey/hook/useSurveyForm.ts
+++ b/src/webapp/components/survey/hook/useSurveyForm.ts
@@ -5,6 +5,7 @@ import { SURVEY_FORM_TYPES } from "../../../../domain/entities/Survey";
 import { OrgUnitAccess } from "../../../../domain/entities/User";
 import { useCurrentSurveys } from "../../../contexts/current-surveys-context";
 import { useHospitalContext } from "../../../contexts/hospital-context";
+import useReadAccess from "./useReadAccess";
 
 export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | undefined) {
     const { compositionRoot, currentUser } = useAppContext();
@@ -20,15 +21,17 @@ export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | und
         currentPrevalenceSurveyForm,
         currentFacilityLevelForm,
     } = useCurrentSurveys();
+    const { hasReadAccess } = useReadAccess();
+
     const [error, setError] = useState<string>();
 
     useEffect(() => {
         if (!questionnaire) setShouldDisableSave(true);
         else {
             const shouldDisable = Questionnaire.doesQuestionnaireHaveErrors(questionnaire);
-            setShouldDisableSave(shouldDisable);
+            setShouldDisableSave(shouldDisable || hasReadAccess);
         }
-    }, [questionnaire]);
+    }, [hasReadAccess, questionnaire]);
 
     useEffect(() => {
         setLoading(true);


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8693zgcet [Read only functionality](https://app.clickup.com/t/8693zgcet)

### :memo: Implementation

- Create a read-only functionality based on the User's group: If he belongs to the module's read access group and not capture and admin groups, he only has read access. The menu items that are capture related are hidden (create/delete), and replaced with a "view" option, that leads to the survey with disabled fields and save button.

### :video_camera: Screenshots/Screen capture
[screen-capture (3).webm](https://github.com/EyeSeeTea/amr-surveys/assets/44171664/1548310d-a697-40a7-a76c-6952d61c46c1)

### :fire: Notes to the tester
- Create a user with a module's read access group and another with it, and check the behaviour of each.
