### PR TITLE
Persist currentModule context within page refresh

### DIFF
--- a/src/webapp/contexts/CurrentModuleContextProvider.tsx
+++ b/src/webapp/contexts/CurrentModuleContextProvider.tsx
@@ -1,12 +1,20 @@
-import { PropsWithChildren, useState } from "react";
+import { PropsWithChildren, useEffect, useState } from "react";
 import { AMRSurveyModule } from "../../domain/entities/AMRSurveyModule";
 import { CurrentModuleContext } from "./current-module-context";
 
 export const CurrentModuleContextProvider: React.FC<PropsWithChildren> = ({ children }) => {
     const [currentModule, setCurrentModule] = useState<AMRSurveyModule | undefined>();
 
+    useEffect(() => {
+        const module = window.sessionStorage.getItem("currentModule");
+        if (module) {
+            setCurrentModule(JSON.parse(module));
+        }
+    }, []);
+
     const changeCurrentModule = (module: AMRSurveyModule | undefined) => {
         setCurrentModule(module);
+        window.sessionStorage.setItem("currentModule", JSON.stringify(module));
     };
 
     const resetCurrentModule = () => {

--- a/src/webapp/contexts/CurrentModuleContextProvider.tsx
+++ b/src/webapp/contexts/CurrentModuleContextProvider.tsx
@@ -7,10 +7,10 @@ export const CurrentModuleContextProvider: React.FC<PropsWithChildren> = ({ chil
 
     useEffect(() => {
         const module = window.sessionStorage.getItem("currentModule");
-        if (module) {
+        if (module && !currentModule) {
             setCurrentModule(JSON.parse(module));
         }
-    }, []);
+    }, [currentModule]);
 
     const changeCurrentModule = (module: AMRSurveyModule | undefined) => {
         setCurrentModule(module);
@@ -19,6 +19,7 @@ export const CurrentModuleContextProvider: React.FC<PropsWithChildren> = ({ chil
 
     const resetCurrentModule = () => {
         setCurrentModule(undefined);
+        window.sessionStorage.removeItem("currentModule");
     };
 
     return (


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes#86948jvz2 [Fix module context on the first list of each module](https://app.clickup.com/t/86948jvz2)

### :memo: Implementation
- Use session storage to persist currentModule within page refreshes

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
