### PR TITLE
Show Antibiotics in grid format and auto populate antibiotics on species select

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-04-01T18:30:50.736Z\n"
-"PO-Revision-Date: 2024-04-01T18:30:50.736Z\n"
+"POT-Creation-Date: 2024-04-24T16:49:08.976Z\n"
+"PO-Revision-Date: 2024-04-24T16:49:08.976Z\n"
 
 msgid "WHO privacy policy"
 msgstr ""
@@ -106,9 +106,6 @@ msgid "Root Survey Name"
 msgstr ""
 
 msgid "Patient Id"
-msgstr ""
-
-msgid "Patient Name"
 msgstr ""
 
 msgid "Action"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-04-01T18:30:50.736Z\n"
+"POT-Creation-Date: 2024-04-24T16:49:08.976Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -106,9 +106,6 @@ msgid "Root Survey Name"
 msgstr ""
 
 msgid "Patient Id"
-msgstr ""
-
-msgid "Patient Name"
 msgstr ""
 
 msgid "Action"

--- a/src/data/repositories/testRepositories/SurveyFormTestRepository.ts
+++ b/src/data/repositories/testRepositories/SurveyFormTestRepository.ts
@@ -49,6 +49,8 @@ export class SurveyTestRepository implements SurveyRepository {
                             questions: [],
                             stageId: "S1",
                             sortOrder: 1,
+                            isAntibioticSection: false,
+                            isSpeciesSection: false,
                         },
                     ],
                     sortOrder: 1,

--- a/src/data/utils/questionHelper.ts
+++ b/src/data/utils/questionHelper.ts
@@ -98,7 +98,11 @@ export const getQuestion = (
                 storeFalse: false,
                 value: name.startsWith("Add new antibiotic")
                     ? true
-                    : !dataValue || dataValue === "true",
+                    : dataValue
+                    ? dataValue === "true"
+                        ? true
+                        : undefined
+                    : undefined,
             };
             return boolQ;
         }

--- a/src/data/utils/questionHelper.ts
+++ b/src/data/utils/questionHelper.ts
@@ -96,13 +96,7 @@ export const getQuestion = (
                 ...base,
                 type: "boolean",
                 storeFalse: false,
-                value: name.startsWith("Add new antibiotic")
-                    ? true
-                    : dataValue
-                    ? dataValue === "true"
-                        ? true
-                        : undefined
-                    : undefined,
+                value: dataValue ? (dataValue === "true" ? true : undefined) : undefined,
             };
             return boolQ;
         }
@@ -137,7 +131,6 @@ export const getQuestion = (
                     const antibioticQ: AntibioticQuestion = {
                         ...selectBase,
                         subType: "select-antibiotic",
-                        filteredOptions: [],
                     };
                     return antibioticQ;
                 } else {

--- a/src/data/utils/questionHelper.ts
+++ b/src/data/utils/questionHelper.ts
@@ -96,7 +96,9 @@ export const getQuestion = (
                 ...base,
                 type: "boolean",
                 storeFalse: false,
-                value: dataValue ? (dataValue === "true" ? true : undefined) : undefined,
+                value: name.startsWith("Add new antibiotic")
+                    ? true
+                    : !dataValue || dataValue === "true",
             };
             return boolQ;
         }

--- a/src/data/utils/surveyFormMappers.ts
+++ b/src/data/utils/surveyFormMappers.ts
@@ -76,12 +76,8 @@ export const mapProgramToQuestionnaire = (
                   isVisible: true,
                   stageId: section.programStage.id,
                   sortOrder: section.sortOrder,
-                  isAntibioticSection: questions.some(
-                      q => q.type === "select" && isAntibioticQuestion(q)
-                  ),
-                  isSpeciesSection: questions.some(
-                      q => q.type === "select" && isSpeciesQuestion(q)
-                  ),
+                  isAntibioticSection: questions.some(isAntibioticQuestion),
+                  isSpeciesSection: questions.some(isSpeciesQuestion),
               };
           })
         : //If the Program has no sections, create a single section
@@ -242,12 +238,8 @@ const getRepeatedStageEvents = (
                     isVisible: true,
                     stageId: newStageId,
                     sortOrder: section.sortOrder,
-                    isAntibioticSection: currentRepeatablequestions.some(
-                        q => q.type === "select" && isAntibioticQuestion(q)
-                    ),
-                    isSpeciesSection: currentRepeatablequestions.some(
-                        q => q.type === "select" && isSpeciesQuestion(q)
-                    ),
+                    isAntibioticSection: currentRepeatablequestions.some(isAntibioticQuestion),
+                    isSpeciesSection: currentRepeatablequestions.some(isSpeciesQuestion),
                 };
             }) ?? [];
 

--- a/src/data/utils/surveyFormMappers.ts
+++ b/src/data/utils/surveyFormMappers.ts
@@ -20,7 +20,11 @@ import {
 import { QuestionnaireSection } from "../../domain/entities/Questionnaire/QuestionnaireSection";
 import { getTrackedEntityAttributeType, isTrackerProgram } from "./surveyProgramHelper";
 import { QuestionnaireRule } from "../../domain/entities/Questionnaire/QuestionnaireRules";
-import { Question } from "../../domain/entities/Questionnaire/QuestionnaireQuestion";
+import {
+    Question,
+    isAntibioticQuestion,
+    isSpeciesQuestion,
+} from "../../domain/entities/Questionnaire/QuestionnaireQuestion";
 import _ from "../../domain/entities/generic/Collection";
 import {
     mapProgramDataElementToQuestions,
@@ -72,6 +76,12 @@ export const mapProgramToQuestionnaire = (
                   isVisible: true,
                   stageId: section.programStage.id,
                   sortOrder: section.sortOrder,
+                  isAntibioticSection: questions.some(
+                      q => q.type === "select" && isAntibioticQuestion(q)
+                  ),
+                  isSpeciesSection: questions.some(
+                      q => q.type === "select" && isSpeciesQuestion(q)
+                  ),
               };
           })
         : //If the Program has no sections, create a single section
@@ -90,6 +100,8 @@ export const mapProgramToQuestionnaire = (
                   isVisible: true,
                   stageId: "default",
                   sortOrder: 1,
+                  isAntibioticSection: false,
+                  isSpeciesSection: false,
               },
           ];
 
@@ -215,7 +227,7 @@ const getRepeatedStageEvents = (
             sections => sections.programStage.id === stage.id
         );
 
-        const currentSections =
+        const currentSections: QuestionnaireSection[] =
             currentRepeatableSections?.map(section => {
                 const currentRepeatablequestions = mapRepeatedStageEventToQuestions(
                     section.dataElements,
@@ -230,6 +242,12 @@ const getRepeatedStageEvents = (
                     isVisible: true,
                     stageId: newStageId,
                     sortOrder: section.sortOrder,
+                    isAntibioticSection: currentRepeatablequestions.some(
+                        q => q.type === "select" && isAntibioticQuestion(q)
+                    ),
+                    isSpeciesSection: currentRepeatablequestions.some(
+                        q => q.type === "select" && isSpeciesQuestion(q)
+                    ),
                 };
             }) ?? [];
 

--- a/src/domain/entities/Questionnaire/Questionnaire.ts
+++ b/src/domain/entities/Questionnaire/Questionnaire.ts
@@ -2,14 +2,7 @@ import { generateUid } from "../../../utils/uid";
 import { SurveyRule } from "../AMRSurveyModule";
 import { Id, Ref } from "../Ref";
 import _ from "../generic/Collection";
-import {
-    AntibioticQuestion,
-    Code,
-    Question,
-    isAntibioticQuestion,
-    isSectionAntibioticQuestion,
-    isSpeciesQuestion,
-} from "./QuestionnaireQuestion";
+import { Code, Question } from "./QuestionnaireQuestion";
 import { QuestionnaireRule, getApplicableRules } from "./QuestionnaireRules";
 import { QuestionnaireSection, QuestionnaireSectionM } from "./QuestionnaireSection";
 
@@ -221,8 +214,7 @@ export class Questionnaire {
     static updateQuestionnaire(
         questionnaire: Questionnaire,
         updatedQuestion: Question,
-        stageId?: string,
-        updatedOptions?: string[]
+        stageId?: string
     ): Questionnaire {
         //For the updated question, get all rules that are applicable
         const allQsInQuestionnaire = questionnaire.stages.flatMap((stage: QuestionnaireStage) => {
@@ -237,7 +229,7 @@ export class Questionnaire {
             allQsInQuestionnaire
         );
 
-        const updatedRulesQuestionnaire = Questionnaire.create({
+        return Questionnaire.create({
             ...questionnaire.data,
             stages: questionnaire.stages.map(stage => {
                 if (stageId && stage.id !== stageId) return stage;
@@ -252,144 +244,6 @@ export class Questionnaire {
                 };
             }),
         });
-
-        return this.handleSpeciesAntibioticQuestionUpdate(
-            updatedRulesQuestionnaire,
-            updatedQuestion,
-            stageId,
-            updatedOptions
-        );
-    }
-
-    static handleSpeciesAntibioticQuestionUpdate(
-        questionnaire: Questionnaire,
-        updatedQuestion: Question,
-        stageId?: string,
-        updatedOptions?: string[]
-    ): Questionnaire {
-        if (updatedQuestion.type === "select") {
-            const stageToUpdate = questionnaire.stages.find(stage => stage.id === stageId);
-
-            if (!stageToUpdate || !stageId) return questionnaire;
-            if (!isSpeciesQuestion(updatedQuestion) && !isAntibioticQuestion(updatedQuestion))
-                return questionnaire;
-
-            const currentSectionIdentifier = isSpeciesQuestion(updatedQuestion)
-                ? updatedQuestion.code.substring(updatedQuestion.code.length - 1)
-                : updatedQuestion.code.substring(
-                      updatedQuestion.code.length - 2,
-                      updatedQuestion.code.length - 1
-                  );
-
-            const updatedSections = isSpeciesQuestion(updatedQuestion)
-                ? this.updatedSectionsOnSpeciesChange(
-                      stageToUpdate,
-                      currentSectionIdentifier,
-                      updatedOptions
-                  )
-                : this.updatedSectionsOnAntibioticChange(
-                      updatedQuestion,
-                      currentSectionIdentifier,
-                      stageToUpdate,
-                      updatedOptions
-                  );
-
-            return Questionnaire.updateQuestionnaireSections(
-                questionnaire,
-                stageId,
-                {
-                    ...stageToUpdate,
-                    sections: updatedSections,
-                },
-                updatedSections
-            );
-        } else return questionnaire;
-    }
-
-    static updatedSectionsOnSpeciesChange(
-        stageToUpdate: QuestionnaireStage,
-        currentSectionIdentifier: string,
-        updatedOptions?: string[]
-    ): QuestionnaireSection[] {
-        const updatedSections = stageToUpdate.sections.map(section => {
-            return {
-                ...section,
-                questions: section.questions.map(question => {
-                    if (isSectionAntibioticQuestion(question, currentSectionIdentifier)) {
-                        const filteredOptions = question.options?.filter(
-                            op => op.code && updatedOptions?.includes(op.code)
-                        );
-                        return {
-                            ...question,
-                            filteredOptions: filteredOptions,
-                            value:
-                                question.value &&
-                                filteredOptions?.find(
-                                    option => option.code === question.value?.code
-                                )
-                                    ? question.value
-                                    : undefined, //reset the antibiotic, if species has changed and the antibiotic is not in the new species options
-                        };
-                    } else return question;
-                }),
-            };
-        });
-
-        return updatedSections;
-    }
-
-    static updatedSectionsOnAntibioticChange(
-        updatedQuestion: AntibioticQuestion,
-        currentSectionIdentifier: string,
-        stageToUpdate: QuestionnaireStage,
-        updatedOptions?: string[]
-    ): QuestionnaireSection[] {
-        const alreadyUsedOptions = _(
-            stageToUpdate.sections.flatMap(section => {
-                return section.questions.map(question => {
-                    if (isSectionAntibioticQuestion(question, currentSectionIdentifier)) {
-                        return question.value?.code;
-                    }
-                });
-            })
-        )
-            .compact()
-            .value();
-
-        const updatedSections = stageToUpdate.sections.map(section => {
-            return {
-                ...section,
-                questions: section.questions.map(question => {
-                    if (isSectionAntibioticQuestion(question, currentSectionIdentifier)) {
-                        if (updatedQuestion.value) {
-                            //Antiobiotice option has been set
-                            const updatedFilteredOptions = question.filteredOptions?.filter(
-                                op => op.code && updatedQuestion.value?.code !== op.code
-                            );
-                            return {
-                                ...question,
-                                filteredOptions: updatedQuestion.value
-                                    ? updatedFilteredOptions
-                                    : question.filteredOptions,
-                            };
-                        } else {
-                            const filteredOptions = question.options?.filter(
-                                op =>
-                                    op.code &&
-                                    updatedOptions?.includes(op.code) &&
-                                    !alreadyUsedOptions.includes(op.code)
-                            );
-                            //Antibiotic option has been reset
-                            return {
-                                ...question,
-                                filteredOptions: filteredOptions,
-                            };
-                        }
-                    } else return question;
-                }),
-            };
-        });
-        return updatedSections;
     }
 
     static doesQuestionnaireHaveErrors(questionnaire: Questionnaire): boolean {

--- a/src/domain/entities/Questionnaire/QuestionnaireQuestion.ts
+++ b/src/domain/entities/Questionnaire/QuestionnaireQuestion.ts
@@ -33,12 +33,40 @@ export interface AntibioticQuestion extends SelectQuestion {
     subType: "select-antibiotic";
 }
 
-export const isSpeciesQuestion = (question: SelectQuestion): question is SpeciesQuestion => {
+export interface ASTResultsQuestion extends SelectQuestion {
+    subType: "select-ast-results";
+}
+
+export interface AntibioticValueQuestion extends TextQuestion {
+    subType: "text-antibiotic-value";
+}
+
+export interface AddNewAntibioticQuestion extends BooleanQuestion {
+    subType: "text-add-new-antibiotic";
+}
+
+export const isSpeciesQuestion = (question: Question): question is SpeciesQuestion => {
     return (question as SpeciesQuestion).subType === "select-species";
 };
 
-export const isAntibioticQuestion = (question: SelectQuestion): question is AntibioticQuestion => {
+export const isAntibioticQuestion = (question: Question): question is AntibioticQuestion => {
     return (question as AntibioticQuestion).subType === "select-antibiotic";
+};
+
+export const isASTResultsQuestion = (question: Question): question is ASTResultsQuestion => {
+    return question.type === "select" && question.text === "AST results";
+};
+
+export const isAntibioticValueQuestion = (
+    question: Question
+): question is AntibioticValueQuestion => {
+    return question.type === "text" && question.text === "Value (unit)";
+};
+
+export const isAddNewAntibioticQuestion = (
+    question: Question
+): question is AddNewAntibioticQuestion => {
+    return question.type === "boolean" && question.text === "Add new antibiotic";
 };
 
 const ANTIBIOTIC_QUESTION_FORM_NAME = "Specify the antibiotic";

--- a/src/domain/entities/Questionnaire/QuestionnaireQuestion.ts
+++ b/src/domain/entities/Questionnaire/QuestionnaireQuestion.ts
@@ -31,7 +31,6 @@ export interface SpeciesQuestion extends SelectQuestion {
 
 export interface AntibioticQuestion extends SelectQuestion {
     subType: "select-antibiotic";
-    filteredOptions?: QuestionOption[];
 }
 
 export const isSpeciesQuestion = (question: SelectQuestion): question is SpeciesQuestion => {

--- a/src/domain/entities/Questionnaire/QuestionnaireSection.ts
+++ b/src/domain/entities/Questionnaire/QuestionnaireSection.ts
@@ -1,5 +1,13 @@
 import { Questionnaire } from "./Questionnaire";
-import { Code, Question, QuestionnaireQuestion } from "./QuestionnaireQuestion";
+import {
+    ASTResultsQuestion,
+    AddNewAntibioticQuestion,
+    AntibioticQuestion,
+    AntibioticValueQuestion,
+    Code,
+    Question,
+    QuestionnaireQuestion,
+} from "./QuestionnaireQuestion";
 import { QuestionnaireRule } from "./QuestionnaireRules";
 import _ from "../generic/Collection";
 
@@ -13,6 +21,13 @@ export interface QuestionnaireSection {
     stageId: string;
     isSpeciesSection: boolean;
     isAntibioticSection: boolean;
+}
+
+export interface AntibioticSection {
+    antibioticQuestion: AntibioticQuestion;
+    astResultsQuestion: ASTResultsQuestion;
+    valueQuestion: AntibioticValueQuestion;
+    addNewAntibioticQuestion: AddNewAntibioticQuestion;
 }
 
 export class QuestionnaireSectionM {

--- a/src/domain/entities/Questionnaire/QuestionnaireSection.ts
+++ b/src/domain/entities/Questionnaire/QuestionnaireSection.ts
@@ -11,6 +11,8 @@ export interface QuestionnaireSection {
     isVisible: boolean;
     sortOrder: number;
     stageId: string;
+    isSpeciesSection: boolean;
+    isAntibioticSection: boolean;
 }
 
 export class QuestionnaireSectionM {

--- a/src/webapp/components/survey-questions/QuestionWidget.tsx
+++ b/src/webapp/components/survey-questions/QuestionWidget.tsx
@@ -13,7 +13,6 @@ import {
     Question,
     QuestionOption,
     QuestionnaireQuestion,
-    isAntibioticQuestion,
 } from "../../../domain/entities/Questionnaire/QuestionnaireQuestion";
 
 export interface QuestionWidgetProps {
@@ -29,18 +28,7 @@ export const QuestionWidget: React.FC<QuestionWidgetProps> = React.memo(props =>
 
     switch (type) {
         case "select": {
-            if (isAntibioticQuestion(question)) {
-                return (
-                    <SearchableSelect
-                        value={question.options.find(op => op.id === question.value?.id) || null}
-                        options={question.filteredOptions ?? []}
-                        onChange={(value: Maybe<QuestionOption>) =>
-                            onChange(update(question, value))
-                        }
-                        disabled={disabled}
-                    />
-                );
-            } else if (question.options.length > 5 && question.options.length < 10) {
+            if (question.options.length > 5 && question.options.length < 10) {
                 return (
                     <DropdownSelectWidget
                         value={question.value?.id}

--- a/src/webapp/components/survey-questions/widgets/SearchableSelect.tsx
+++ b/src/webapp/components/survey-questions/widgets/SearchableSelect.tsx
@@ -6,12 +6,13 @@ import TextField from "@mui/material/TextField";
 export interface SearchableSelectProps extends BaseWidgetProps<Option> {
     value: Option | null;
     options: Option[];
+    label?: string;
 }
 
 type Option = { id: string; name: string };
 
 const SearchableSelect: React.FC<SearchableSelectProps> = props => {
-    const { onChange: onValueChange, value, options, disabled } = props;
+    const { onChange: onValueChange, value, options, disabled, label } = props;
 
     const [stateValue, setStateValue] = React.useState(value);
     React.useEffect(() => setStateValue(value), [value]);
@@ -33,7 +34,7 @@ const SearchableSelect: React.FC<SearchableSelectProps> = props => {
             disablePortal
             options={options}
             sx={{ width: 300 }}
-            renderInput={params => <TextField {...params} label="Select..." />}
+            renderInput={params => <TextField {...params} label={label ?? "Select..."} />}
             disabled={disabled}
         />
     );

--- a/src/webapp/components/survey-questions/widgets/TextWidget.tsx
+++ b/src/webapp/components/survey-questions/widgets/TextWidget.tsx
@@ -7,10 +7,11 @@ import { Maybe } from "../../../../utils/ts-utils";
 export interface TextWidgetProps extends BaseWidgetProps<string> {
     value: Maybe<string>;
     multiline: boolean;
+    placeholder?: string;
 }
 
 const TextWidget: React.FC<TextWidgetProps> = props => {
-    const { onChange: onValueChange, value } = props;
+    const { onChange: onValueChange, value, placeholder } = props;
 
     const [stateValue, setStateValue] = React.useState(value);
     React.useEffect(() => setStateValue(value), [value]);
@@ -37,6 +38,7 @@ const TextWidget: React.FC<TextWidgetProps> = props => {
                 />
             ) : (
                 <Input
+                    placeholder={placeholder}
                     onBlur={notifyChange}
                     onChange={updateState}
                     value={stateValue || ""}

--- a/src/webapp/components/survey/GridRow.tsx
+++ b/src/webapp/components/survey/GridRow.tsx
@@ -1,0 +1,93 @@
+import SearchableSelect from "../survey-questions/widgets/SearchableSelect";
+import {
+    AntibioticQuestion,
+    Question,
+    QuestionOption,
+    QuestionnaireQuestion,
+    SelectQuestion,
+    TextQuestion,
+} from "../../../domain/entities/Questionnaire/QuestionnaireQuestion";
+import TextWidget from "../survey-questions/widgets/TextWidget";
+import styled from "styled-components";
+import { useEffect } from "react";
+import { Typography } from "@material-ui/core";
+
+interface GridRowProps {
+    option: string;
+    antibiotic: AntibioticQuestion;
+    astResults: SelectQuestion;
+    valueQuestion: TextQuestion;
+    updateAstResults: (question: Question) => void;
+    updateValue: (question: Question) => void;
+    updateAntibitoticQuestion: (question: Question) => void;
+}
+
+export const GridRow: React.FC<GridRowProps> = ({
+    option,
+    antibiotic,
+    astResults,
+    valueQuestion,
+    updateAstResults,
+    updateValue,
+    updateAntibitoticQuestion,
+}) => {
+    const { update } = QuestionnaireQuestion;
+
+    useEffect(() => {
+        const updatedAntibiotic = {
+            ...antibiotic,
+            value: antibiotic.options.find(op => op.name === option),
+        };
+
+        updateAntibitoticQuestion(updatedAntibiotic);
+    }, [antibiotic, option, updateAntibitoticQuestion]);
+
+    return (
+        <StyledRow>
+            <StyledTypo>{option}</StyledTypo>
+            <StyledSearchableSelect
+                value={astResults.options.find(op => op.id === astResults.value?.id) || null}
+                options={astResults.options ?? []}
+                onChange={(value: QuestionOption) => updateAstResults(update(astResults, value))}
+                disabled={false}
+                label="Select AST results"
+            />
+
+            <StyledTextWidget
+                value={valueQuestion?.value}
+                onChange={value => updateValue(update(valueQuestion, value))}
+                disabled={false}
+                multiline={valueQuestion?.multiline ?? false}
+                placeholder="Value (unit)"
+            />
+        </StyledRow>
+    );
+};
+
+const StyledRow = styled.div`
+    max-width: 30%;
+    border: 1px solid black;
+    display: flex;
+    flex-direction: row;
+    gap: 5px;
+    padding: 10px;
+    align-items: center;
+`;
+
+const StyledTypo = styled(Typography)`
+    width: 50%;
+    max-width: 50%;
+    overflow: ellipsis;
+    text-align: center;
+`;
+const StyledSearchableSelect = styled(SearchableSelect)`
+    width: 50%;
+    max-width: 40%;
+    height: 40px;
+    max-height: 40px;
+`;
+
+const StyledTextWidget = styled(TextWidget)`
+    width: 20px;
+    max-width: 20px;
+`;

--- a/src/webapp/components/survey/GridRow.tsx
+++ b/src/webapp/components/survey/GridRow.tsx
@@ -1,73 +1,51 @@
 import SearchableSelect from "../survey-questions/widgets/SearchableSelect";
 import {
+    ASTResultsQuestion,
+    AddNewAntibioticQuestion,
     AntibioticQuestion,
-    BooleanQuestion,
+    AntibioticValueQuestion,
     Question,
     QuestionOption,
     QuestionnaireQuestion,
-    SelectQuestion,
-    TextQuestion,
 } from "../../../domain/entities/Questionnaire/QuestionnaireQuestion";
 import TextWidget from "../survey-questions/widgets/TextWidget";
 import styled from "styled-components";
-import { useCallback } from "react";
 import { Typography } from "@material-ui/core";
+import { useGridRow } from "./hook/useGridRow";
 
 interface GridRowProps {
     option: string;
     antibiotic: AntibioticQuestion;
-    astResults: SelectQuestion;
-    valueQuestion: TextQuestion;
-    addNewAntibioticQuestion: BooleanQuestion;
+    astResults: ASTResultsQuestion;
+    valueQuestion: AntibioticValueQuestion;
+    addNewAntibioticQuestion: AddNewAntibioticQuestion;
     updateAstResults: (question: Question) => void;
     updateValue: (question: Question) => void;
     updateAntibitoticQuestion: (question: Question) => void;
     updateAddNewAntibiotic: (question: Question) => void;
 }
 
-export const GridRow: React.FC<GridRowProps> = ({
-    option,
-    antibiotic,
-    astResults,
-    valueQuestion,
-    addNewAntibioticQuestion,
-    updateAstResults,
-    updateValue,
-    updateAntibitoticQuestion,
-    updateAddNewAntibiotic,
-}) => {
+export const GridRow: React.FC<GridRowProps> = props => {
+    const {
+        option,
+        antibiotic,
+        astResults,
+        valueQuestion,
+        addNewAntibioticQuestion,
+        updateAstResults,
+        updateValue,
+        updateAntibitoticQuestion,
+        updateAddNewAntibiotic,
+    } = props;
     const { update } = QuestionnaireQuestion;
-
-    const updateGridRow = useCallback(
-        (question: Question) => {
-            if (question.type === "select") {
-                updateAstResults(question);
-            } else if (question.type === "text") {
-                updateValue(question);
-            }
-            const updatedAntibiotic: AntibioticQuestion = {
-                ...antibiotic,
-                value: antibiotic.options.find(op => op.name === option),
-            };
-
-            updateAntibitoticQuestion(updatedAntibiotic);
-
-            const newAddNewAntibiotic: BooleanQuestion = {
-                ...addNewAntibioticQuestion,
-                value: true,
-            };
-
-            updateAddNewAntibiotic(newAddNewAntibiotic);
-        },
-        [
-            antibiotic,
-            option,
-            updateAstResults,
-            updateValue,
-            updateAntibitoticQuestion,
-            addNewAntibioticQuestion,
-            updateAddNewAntibiotic,
-        ]
+    const { updateGridRow } = useGridRow(
+        updateAstResults,
+        updateValue,
+        antibiotic,
+        option,
+        updateAntibitoticQuestion,
+        addNewAntibioticQuestion,
+        updateAddNewAntibiotic
     );
 
     return (

--- a/src/webapp/components/survey/GridRow.tsx
+++ b/src/webapp/components/survey/GridRow.tsx
@@ -1,6 +1,7 @@
 import SearchableSelect from "../survey-questions/widgets/SearchableSelect";
 import {
     AntibioticQuestion,
+    BooleanQuestion,
     Question,
     QuestionOption,
     QuestionnaireQuestion,
@@ -9,7 +10,7 @@ import {
 } from "../../../domain/entities/Questionnaire/QuestionnaireQuestion";
 import TextWidget from "../survey-questions/widgets/TextWidget";
 import styled from "styled-components";
-import { useEffect } from "react";
+import { useCallback } from "react";
 import { Typography } from "@material-ui/core";
 
 interface GridRowProps {
@@ -17,9 +18,11 @@ interface GridRowProps {
     antibiotic: AntibioticQuestion;
     astResults: SelectQuestion;
     valueQuestion: TextQuestion;
+    addNewAntibioticQuestion: BooleanQuestion;
     updateAstResults: (question: Question) => void;
     updateValue: (question: Question) => void;
     updateAntibitoticQuestion: (question: Question) => void;
+    updateAddNewAntibiotic: (question: Question) => void;
 }
 
 export const GridRow: React.FC<GridRowProps> = ({
@@ -27,20 +30,45 @@ export const GridRow: React.FC<GridRowProps> = ({
     antibiotic,
     astResults,
     valueQuestion,
+    addNewAntibioticQuestion,
     updateAstResults,
     updateValue,
     updateAntibitoticQuestion,
+    updateAddNewAntibiotic,
 }) => {
     const { update } = QuestionnaireQuestion;
 
-    useEffect(() => {
-        const updatedAntibiotic = {
-            ...antibiotic,
-            value: antibiotic.options.find(op => op.name === option),
-        };
+    const updateGridRow = useCallback(
+        (question: Question) => {
+            if (question.type === "select") {
+                updateAstResults(question);
+            } else if (question.type === "text") {
+                updateValue(question);
+            }
+            const updatedAntibiotic: AntibioticQuestion = {
+                ...antibiotic,
+                value: antibiotic.options.find(op => op.name === option),
+            };
 
-        updateAntibitoticQuestion(updatedAntibiotic);
-    }, [antibiotic, option, updateAntibitoticQuestion]);
+            updateAntibitoticQuestion(updatedAntibiotic);
+
+            const newAddNewAntibiotic: BooleanQuestion = {
+                ...addNewAntibioticQuestion,
+                value: true,
+            };
+
+            updateAddNewAntibiotic(newAddNewAntibiotic);
+        },
+        [
+            antibiotic,
+            option,
+            updateAstResults,
+            updateValue,
+            updateAntibitoticQuestion,
+            addNewAntibioticQuestion,
+            updateAddNewAntibiotic,
+        ]
+    );
 
     return (
         <StyledRow>
@@ -48,14 +76,14 @@ export const GridRow: React.FC<GridRowProps> = ({
             <StyledSearchableSelect
                 value={astResults.options.find(op => op.id === astResults.value?.id) || null}
                 options={astResults.options ?? []}
-                onChange={(value: QuestionOption) => updateAstResults(update(astResults, value))}
+                onChange={(value: QuestionOption) => updateGridRow(update(astResults, value))}
                 disabled={false}
                 label="Select AST results"
             />
 
             <StyledTextWidget
                 value={valueQuestion?.value}
-                onChange={value => updateValue(update(valueQuestion, value))}
+                onChange={value => updateGridRow(update(valueQuestion, value))}
                 disabled={false}
                 multiline={valueQuestion?.multiline ?? false}
                 placeholder="Value (unit)"

--- a/src/webapp/components/survey/GridSection.tsx
+++ b/src/webapp/components/survey/GridSection.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import {
     AntibioticQuestion,
+    BooleanQuestion,
     Question,
     SelectQuestion,
     TextQuestion,
@@ -53,12 +54,19 @@ export const GridSection: React.FC<GridSectionProps> = React.memo(
                 const valueQuestion = section?.questions.find(
                     q => q.type === "text" && q.text === "Value (unit)"
                 );
+                const addNewAntibioticQuestion = section?.questions.find(
+                    q => q.type === "boolean" && q.text === "Add new antibiotic"
+                );
 
-                return {
+                const antiBioticSet: AntibioticSection = {
                     antibioticQuestion: antibioticQuestion as unknown as AntibioticQuestion,
-                    astResults: astQuestion as unknown as SelectQuestion,
+                    astResultsQuestion: astQuestion as unknown as SelectQuestion,
                     valueQuestion: valueQuestion as unknown as TextQuestion,
+                    addNewAntibioticQuestion:
+                        addNewAntibioticQuestion as unknown as BooleanQuestion,
                 };
+
+                return antiBioticSet;
             });
 
             setAntibioticSets(antibioticGroups);
@@ -94,11 +102,15 @@ export const GridSection: React.FC<GridSectionProps> = React.memo(
                                 key={option}
                                 option={option}
                                 antibiotic={currentAntibiotic.antibioticQuestion}
-                                astResults={currentAntibiotic.astResults}
+                                astResults={currentAntibiotic.astResultsQuestion}
                                 valueQuestion={currentAntibiotic.valueQuestion}
+                                addNewAntibioticQuestion={
+                                    currentAntibiotic.addNewAntibioticQuestion
+                                }
                                 updateAntibitoticQuestion={updateQuestion}
                                 updateAstResults={updateQuestion}
                                 updateValue={updateQuestion}
+                                updateAddNewAntibiotic={updateQuestion}
                             />
                         );
                     })}

--- a/src/webapp/components/survey/GridSection.tsx
+++ b/src/webapp/components/survey/GridSection.tsx
@@ -1,21 +1,14 @@
 import styled from "styled-components";
-import {
-    AntibioticQuestion,
-    BooleanQuestion,
-    Question,
-    SelectQuestion,
-    TextQuestion,
-    isAntibioticQuestion,
-    isSpeciesQuestion,
-} from "../../../domain/entities/Questionnaire/QuestionnaireQuestion";
+import { Question } from "../../../domain/entities/Questionnaire/QuestionnaireQuestion";
 import { GridRow } from "./GridRow";
 import _ from "../../../domain/entities/generic/Collection";
-import { AntibioticSection } from "./SurveyForm";
 import { QuestionnaireSection } from "../../../domain/entities/Questionnaire/QuestionnaireSection";
 import { QuestionnaireStage } from "../../../domain/entities/Questionnaire/Questionnaire";
 import { SurveySection } from "./SurveySection";
-import React, { useCallback, useEffect, useState } from "react";
-import { useASTGuidelinesOptions } from "../../hooks/useASTGuidelinesOptions";
+import React from "react";
+
+import _c from "../../../domain/entities/generic/Collection";
+import { useGridSection } from "./hook/useGridSection";
 
 interface GridSectionProps {
     speciesSection: QuestionnaireSection;
@@ -26,88 +19,10 @@ interface GridSectionProps {
 
 export const GridSection: React.FC<GridSectionProps> = React.memo(
     ({ speciesSection, antibioticStage, updateQuestion, viewOnly }) => {
-        const { getAntibioticOptions } = useASTGuidelinesOptions();
-        const [gridOptions, setGridOptions] = useState<string[]>();
-        const [antibioticSets, setAntibioticSets] = useState<AntibioticSection[]>();
-
-        useEffect(() => {
-            const speciesQuestion = speciesSection.questions.find(
-                question => question.type === "select" && isSpeciesQuestion(question)
-            );
-            if (speciesQuestion?.type === "select" && isSpeciesQuestion(speciesQuestion)) {
-                const options = getAntibioticOptions(speciesQuestion);
-                setGridOptions(options);
-            }
-
-            const antibioticSections = antibioticStage.sections.filter(
-                section => section.isAntibioticSection
-            );
-            const antibioticGroups: AntibioticSection[] = antibioticSections.map(section => {
-                const antibioticQuestion = section?.questions.find(
-                    q => q.type === "select" && isAntibioticQuestion(q)
-                );
-
-                const astQuestion = section?.questions.find(
-                    q => q.type === "select" && q.text === "AST results"
-                );
-
-                const valueQuestion = section?.questions.find(
-                    q => q.type === "text" && q.text === "Value (unit)"
-                );
-                const addNewAntibioticQuestion = section?.questions.find(
-                    q => q.type === "boolean" && q.text === "Add new antibiotic"
-                );
-
-                const antiBioticSet: AntibioticSection = {
-                    antibioticQuestion: antibioticQuestion as unknown as AntibioticQuestion,
-                    astResultsQuestion: astQuestion as unknown as SelectQuestion,
-                    valueQuestion: valueQuestion as unknown as TextQuestion,
-                    addNewAntibioticQuestion:
-                        addNewAntibioticQuestion as unknown as BooleanQuestion,
-                };
-
-                return antiBioticSet;
-            });
-
-            setAntibioticSets(antibioticGroups);
-        }, [antibioticStage.sections, getAntibioticOptions, gridOptions, speciesSection.questions]);
-
-        const updateSpeciesQuestion = useCallback(
-            (question: Question) => {
-                if (question.type === "select" && isSpeciesQuestion(question)) {
-                    const options = getAntibioticOptions(question);
-                    setGridOptions(options);
-                    antibioticSets?.map(antibioticSet => {
-                        if (antibioticSet.addNewAntibioticQuestion?.value) {
-                            updateQuestion({
-                                ...antibioticSet.addNewAntibioticQuestion,
-                                value: false,
-                            });
-                        }
-                        if (antibioticSet.antibioticQuestion?.value) {
-                            updateQuestion({
-                                ...antibioticSet.antibioticQuestion,
-                                value: undefined,
-                            });
-                        }
-
-                        if (antibioticSet.astResultsQuestion?.value) {
-                            updateQuestion({
-                                ...antibioticSet.astResultsQuestion,
-                                value: undefined,
-                            });
-                        }
-                        if (antibioticSet.valueQuestion?.value) {
-                            updateQuestion({
-                                ...antibioticSet.valueQuestion,
-                                value: undefined,
-                            });
-                        }
-                    });
-                }
-                updateQuestion(question);
-            },
-            [antibioticSets, getAntibioticOptions, updateQuestion, setGridOptions]
+        const { updateSpeciesQuestion, gridOptions, antibioticSets } = useGridSection(
+            speciesSection,
+            antibioticStage,
+            updateQuestion
         );
 
         return (

--- a/src/webapp/components/survey/GridSection.tsx
+++ b/src/webapp/components/survey/GridSection.tsx
@@ -84,6 +84,7 @@ export const GridSection: React.FC<GridSectionProps> = React.memo(
                     title={speciesSection.title}
                     questions={speciesSection.questions}
                     viewOnly={viewOnly}
+                    updateQuestion={updateSpeciesQuestion}
                 />
                 <StyledColumn>
                     {gridOptions?.map((option, index) => {

--- a/src/webapp/components/survey/GridSection.tsx
+++ b/src/webapp/components/survey/GridSection.tsx
@@ -26,8 +26,8 @@ interface GridSectionProps {
 
 export const GridSection: React.FC<GridSectionProps> = React.memo(
     ({ speciesSection, antibioticStage, updateQuestion, viewOnly }) => {
-        const [gridOptions, setGridOptions] = useState<string[]>();
         const { getAntibioticOptions } = useASTGuidelinesOptions();
+        const [gridOptions, setGridOptions] = useState<string[]>();
         const [antibioticSets, setAntibioticSets] = useState<AntibioticSection[]>();
 
         useEffect(() => {
@@ -77,10 +77,37 @@ export const GridSection: React.FC<GridSectionProps> = React.memo(
                 if (question.type === "select" && isSpeciesQuestion(question)) {
                     const options = getAntibioticOptions(question);
                     setGridOptions(options);
+                    antibioticSets?.map(antibioticSet => {
+                        if (antibioticSet.addNewAntibioticQuestion?.value) {
+                            updateQuestion({
+                                ...antibioticSet.addNewAntibioticQuestion,
+                                value: false,
+                            });
+                        }
+                        if (antibioticSet.antibioticQuestion?.value) {
+                            updateQuestion({
+                                ...antibioticSet.antibioticQuestion,
+                                value: undefined,
+                            });
+                        }
+
+                        if (antibioticSet.astResultsQuestion?.value) {
+                            updateQuestion({
+                                ...antibioticSet.astResultsQuestion,
+                                value: undefined,
+                            });
+                        }
+                        if (antibioticSet.valueQuestion?.value) {
+                            updateQuestion({
+                                ...antibioticSet.valueQuestion,
+                                value: undefined,
+                            });
+                        }
+                    });
                 }
                 updateQuestion(question);
             },
-            [getAntibioticOptions, updateQuestion]
+            [antibioticSets, getAntibioticOptions, updateQuestion, setGridOptions]
         );
 
         return (

--- a/src/webapp/components/survey/GridSection.tsx
+++ b/src/webapp/components/survey/GridSection.tsx
@@ -30,7 +30,6 @@ export const GridSection: React.FC<GridSectionProps> = React.memo(
         const [antibioticSets, setAntibioticSets] = useState<AntibioticSection[]>();
 
         useEffect(() => {
-            console.debug("GridSection useEffect");
             const speciesQuestion = speciesSection.questions.find(
                 question => question.type === "select" && isSpeciesQuestion(question)
             );
@@ -54,7 +53,6 @@ export const GridSection: React.FC<GridSectionProps> = React.memo(
                 const valueQuestion = section?.questions.find(
                     q => q.type === "text" && q.text === "Value (unit)"
                 );
-                // if (!antibioticQuestion || !astQuestion || !valueQuestion) return null;
 
                 return {
                     antibioticQuestion: antibioticQuestion as unknown as AntibioticQuestion,

--- a/src/webapp/components/survey/GridSection.tsx
+++ b/src/webapp/components/survey/GridSection.tsx
@@ -1,0 +1,113 @@
+import styled from "styled-components";
+import {
+    AntibioticQuestion,
+    Question,
+    SelectQuestion,
+    TextQuestion,
+    isAntibioticQuestion,
+    isSpeciesQuestion,
+} from "../../../domain/entities/Questionnaire/QuestionnaireQuestion";
+import { GridRow } from "./GridRow";
+import _ from "../../../domain/entities/generic/Collection";
+import { AntibioticSection } from "./SurveyForm";
+import { QuestionnaireSection } from "../../../domain/entities/Questionnaire/QuestionnaireSection";
+import { QuestionnaireStage } from "../../../domain/entities/Questionnaire/Questionnaire";
+import { SurveySection } from "./SurveySection";
+import { useCallback, useEffect, useState } from "react";
+import { useASTGuidelinesOptions } from "../../hooks/useASTGuidelinesOptions";
+
+interface GridSectionProps {
+    speciesSection: QuestionnaireSection;
+    antibioticStage: QuestionnaireStage;
+    updateQuestion: (question: Question) => void;
+    viewOnly?: boolean;
+}
+
+export const GridSection: React.FC<GridSectionProps> = ({
+    speciesSection,
+    antibioticStage,
+    updateQuestion,
+    viewOnly,
+}) => {
+    const [gridOptions, setGridOptions] = useState<string[]>();
+    const { getAntibioticOptions } = useASTGuidelinesOptions();
+    const [antibioticSets, setAntibioticSets] = useState<AntibioticSection[]>();
+
+    useEffect(() => {
+        const antibioticSections = antibioticStage.sections.filter(
+            section => section.isAntibioticSection
+        );
+        const antibioticGroups: AntibioticSection[] = antibioticSections.map(section => {
+            const antibioticQuestion = section?.questions.find(
+                q => q.type === "select" && isAntibioticQuestion(q)
+            );
+
+            const astQuestion = section?.questions.find(
+                q => q.type === "select" && q.text === "AST results"
+            );
+
+            const valueQuestion = section?.questions.find(
+                q => q.type === "text" && q.text === "Value (unit)"
+            );
+            // if (!antibioticQuestion || !astQuestion || !valueQuestion) return null;
+
+            return {
+                antibioticQuestion: antibioticQuestion as unknown as AntibioticQuestion,
+                astResults: astQuestion as unknown as SelectQuestion,
+                valueQuestion: valueQuestion as unknown as TextQuestion,
+            };
+        });
+
+        setAntibioticSets(antibioticGroups);
+    }, [antibioticStage.sections]);
+
+    const updateSpeciesQuestion = useCallback(
+        (question: Question) => {
+            if (question.type === "select" && isSpeciesQuestion(question)) {
+                const options = getAntibioticOptions(question);
+                setGridOptions(options);
+            }
+            updateQuestion(question);
+        },
+        [getAntibioticOptions, updateQuestion]
+    );
+
+    return (
+        <>
+            <SurveySection
+                key={speciesSection.code}
+                title={speciesSection.title}
+                updateQuestion={question => updateSpeciesQuestion(question)}
+                questions={speciesSection.questions}
+                viewOnly={viewOnly}
+            />
+            <StyledColumn>
+                {gridOptions?.map((option, index) => {
+                    const currentAntibiotic = antibioticSets?.at(index);
+                    if (!currentAntibiotic) return null;
+
+                    return (
+                        <GridRow
+                            key={option}
+                            option={option}
+                            antibiotic={currentAntibiotic.antibioticQuestion}
+                            astResults={currentAntibiotic.astResults}
+                            valueQuestion={currentAntibiotic.valueQuestion}
+                            updateAntibitoticQuestion={updateQuestion}
+                            updateAstResults={updateQuestion}
+                            updateValue={updateQuestion}
+                        />
+                    );
+                })}
+            </StyledColumn>
+        </>
+    );
+};
+
+const StyledColumn = styled.div`
+    display: flex;
+    flex-flow: row wrap;
+    max-width: 100%;
+    padding-top: 10px;
+    gap: 30px;
+`;

--- a/src/webapp/components/survey/SurveyForm.tsx
+++ b/src/webapp/components/survey/SurveyForm.tsx
@@ -14,6 +14,13 @@ import { SurveyFormOUSelector } from "./SurveyFormOUSelector";
 import { SurveySection } from "./SurveySection";
 import { useHistory } from "react-router-dom";
 import useReadOnlyAccess from "./hook/useReadOnlyAccess";
+import {
+    AntibioticQuestion,
+    SelectQuestion,
+    TextQuestion,
+} from "../../../domain/entities/Questionnaire/QuestionnaireQuestion";
+import { GridSection } from "./GridSection";
+import _c from "../../../domain/entities/generic/Collection";
 
 export interface SurveyFormProps {
     hideForm: () => void;
@@ -31,6 +38,12 @@ const CancelButton = withStyles(() => ({
         marginRight: "10px",
     },
 }))(Button);
+
+export interface AntibioticSection {
+    antibioticQuestion: AntibioticQuestion;
+    astResults: SelectQuestion;
+    valueQuestion: TextQuestion;
+}
 
 export const SurveyForm: React.FC<SurveyFormProps> = props => {
     const snackbar = useSnackbar();
@@ -132,9 +145,20 @@ export const SurveyForm: React.FC<SurveyFormProps> = props => {
                                     )}
                                 </RightAlignedDiv>
                             )}
-
                             {stage.sections.map(section => {
-                                if (!section.isVisible) return null;
+                                if (!section.isVisible || section.isAntibioticSection) return null;
+
+                                if (section.isSpeciesSection)
+                                    return (
+                                        <GridSection
+                                            speciesSection={section}
+                                            antibioticStage={stage}
+                                            updateQuestion={question =>
+                                                updateQuestion(question, stage.id)
+                                            }
+                                            viewOnly={hasReadOnlyAccess}
+                                        />
+                                    );
 
                                 return (
                                     <SurveySection

--- a/src/webapp/components/survey/SurveyForm.tsx
+++ b/src/webapp/components/survey/SurveyForm.tsx
@@ -16,6 +16,7 @@ import { useHistory } from "react-router-dom";
 import useReadOnlyAccess from "./hook/useReadOnlyAccess";
 import {
     AntibioticQuestion,
+    BooleanQuestion,
     SelectQuestion,
     TextQuestion,
 } from "../../../domain/entities/Questionnaire/QuestionnaireQuestion";
@@ -41,8 +42,9 @@ const CancelButton = withStyles(() => ({
 
 export interface AntibioticSection {
     antibioticQuestion: AntibioticQuestion;
-    astResults: SelectQuestion;
+    astResultsQuestion: SelectQuestion;
     valueQuestion: TextQuestion;
+    addNewAntibioticQuestion: BooleanQuestion;
 }
 
 export const SurveyForm: React.FC<SurveyFormProps> = props => {

--- a/src/webapp/components/survey/SurveyForm.tsx
+++ b/src/webapp/components/survey/SurveyForm.tsx
@@ -14,12 +14,6 @@ import { SurveyFormOUSelector } from "./SurveyFormOUSelector";
 import { SurveySection } from "./SurveySection";
 import { useHistory } from "react-router-dom";
 import useReadOnlyAccess from "./hook/useReadOnlyAccess";
-import {
-    AntibioticQuestion,
-    BooleanQuestion,
-    SelectQuestion,
-    TextQuestion,
-} from "../../../domain/entities/Questionnaire/QuestionnaireQuestion";
 import { GridSection } from "./GridSection";
 import _c from "../../../domain/entities/generic/Collection";
 
@@ -39,13 +33,6 @@ const CancelButton = withStyles(() => ({
         marginRight: "10px",
     },
 }))(Button);
-
-export interface AntibioticSection {
-    antibioticQuestion: AntibioticQuestion;
-    astResultsQuestion: SelectQuestion;
-    valueQuestion: TextQuestion;
-    addNewAntibioticQuestion: BooleanQuestion;
-}
 
 export const SurveyForm: React.FC<SurveyFormProps> = props => {
     const snackbar = useSnackbar();

--- a/src/webapp/components/survey/SurveySection.tsx
+++ b/src/webapp/components/survey/SurveySection.tsx
@@ -86,7 +86,7 @@ const PaddedDiv = styled.div`
 
 const StyledSection = styled.div``;
 
-const StyledTitle = styled.span`
+export const StyledTitle = styled.span`
     fontweight: "bold" as const;
 `;
 

--- a/src/webapp/components/survey/hook/useGridRow.ts
+++ b/src/webapp/components/survey/hook/useGridRow.ts
@@ -1,0 +1,52 @@
+import { useCallback } from "react";
+import {
+    AntibioticQuestion,
+    BooleanQuestion,
+    Question,
+    isASTResultsQuestion,
+    isAntibioticValueQuestion,
+} from "../../../../domain/entities/Questionnaire/QuestionnaireQuestion";
+
+export const useGridRow = (
+    updateAstResults: (question: Question) => void,
+    updateValue: (question: Question) => void,
+    antibiotic: AntibioticQuestion,
+    option: string,
+    updateAntibitoticQuestion: (question: Question) => void,
+    addNewAntibioticQuestion: BooleanQuestion,
+    updateAddNewAntibiotic: (question: Question) => void
+) => {
+    const updateGridRow = useCallback(
+        (question: Question) => {
+            if (isASTResultsQuestion(question)) {
+                updateAstResults(question);
+            } else if (isAntibioticValueQuestion(question)) {
+                updateValue(question);
+            }
+            const updatedAntibiotic: AntibioticQuestion = {
+                ...antibiotic,
+                value: antibiotic.options.find(op => op.name === option),
+            };
+
+            updateAntibitoticQuestion(updatedAntibiotic);
+
+            const newAddNewAntibiotic: BooleanQuestion = {
+                ...addNewAntibioticQuestion,
+                value: true,
+            };
+
+            updateAddNewAntibiotic(newAddNewAntibiotic);
+        },
+        [
+            addNewAntibioticQuestion,
+            antibiotic,
+            option,
+            updateAddNewAntibiotic,
+            updateAntibitoticQuestion,
+            updateAstResults,
+            updateValue,
+        ]
+    );
+
+    return { updateGridRow };
+};

--- a/src/webapp/components/survey/hook/useGridSection.ts
+++ b/src/webapp/components/survey/hook/useGridSection.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useState } from "react";
+import { useASTGuidelinesOptions } from "../../../hooks/useASTGuidelinesOptions";
+import {
+    AntibioticSection,
+    QuestionnaireSection,
+} from "../../../../domain/entities/Questionnaire/QuestionnaireSection";
+import {
+    Question,
+    isASTResultsQuestion,
+    isAddNewAntibioticQuestion,
+    isAntibioticQuestion,
+    isAntibioticValueQuestion,
+    isSpeciesQuestion,
+} from "../../../../domain/entities/Questionnaire/QuestionnaireQuestion";
+import { QuestionnaireStage } from "../../../../domain/entities/Questionnaire/Questionnaire";
+import _c from "../../../../domain/entities/generic/Collection";
+
+export const useGridSection = (
+    speciesSection: QuestionnaireSection,
+    antibioticStage: QuestionnaireStage,
+    updateQuestion: (question: Question) => void
+) => {
+    const { getAntibioticOptions } = useASTGuidelinesOptions();
+    const [gridOptions, setGridOptions] = useState<string[]>();
+    const [antibioticSets, setAntibioticSets] = useState<AntibioticSection[]>();
+
+    useEffect(() => {
+        const speciesQuestion = speciesSection.questions.find(isSpeciesQuestion);
+        if (speciesQuestion) {
+            const options = getAntibioticOptions(speciesQuestion);
+            setGridOptions(options);
+        }
+
+        const antibioticSections = antibioticStage.sections.filter(
+            section => section.isAntibioticSection
+        );
+        const antibioticGroups: AntibioticSection[] = _c(
+            antibioticSections.map(section => {
+                const antibioticQuestion = section?.questions.find(isAntibioticQuestion);
+                const astQuestion = section?.questions.find(isASTResultsQuestion);
+                const valueQuestion = section?.questions.find(isAntibioticValueQuestion);
+                const addNewAntibioticQuestion = section?.questions.find(
+                    isAddNewAntibioticQuestion
+                );
+
+                if (
+                    !antibioticQuestion ||
+                    !astQuestion ||
+                    !valueQuestion ||
+                    !addNewAntibioticQuestion
+                )
+                    return null;
+
+                const antiBioticSet: AntibioticSection = {
+                    antibioticQuestion: antibioticQuestion,
+                    astResultsQuestion: astQuestion,
+                    valueQuestion: valueQuestion,
+                    addNewAntibioticQuestion: addNewAntibioticQuestion,
+                };
+
+                return antiBioticSet;
+            })
+        )
+            .compact()
+            .value();
+
+        setAntibioticSets(antibioticGroups);
+    }, [antibioticStage.sections, getAntibioticOptions, gridOptions, speciesSection.questions]);
+
+    const updateSpeciesQuestion = useCallback(
+        (question: Question) => {
+            if (isSpeciesQuestion(question)) {
+                const options = getAntibioticOptions(question);
+                setGridOptions(options);
+                antibioticSets?.map(antibioticSet => {
+                    if (antibioticSet.addNewAntibioticQuestion?.value) {
+                        updateQuestion({
+                            ...antibioticSet.addNewAntibioticQuestion,
+                            value: false,
+                        });
+                    }
+                    if (antibioticSet.antibioticQuestion?.value) {
+                        updateQuestion({
+                            ...antibioticSet.antibioticQuestion,
+                            value: undefined,
+                        });
+                    }
+
+                    if (antibioticSet.astResultsQuestion?.value) {
+                        updateQuestion({
+                            ...antibioticSet.astResultsQuestion,
+                            value: undefined,
+                        });
+                    }
+                    if (antibioticSet.valueQuestion?.value) {
+                        updateQuestion({
+                            ...antibioticSet.valueQuestion,
+                            value: undefined,
+                        });
+                    }
+                });
+            }
+            updateQuestion(question);
+        },
+        [antibioticSets, getAntibioticOptions, updateQuestion, setGridOptions]
+    );
+
+    return { updateSpeciesQuestion, gridOptions, antibioticSets };
+};

--- a/src/webapp/components/survey/hook/useSurveyForm.ts
+++ b/src/webapp/components/survey/hook/useSurveyForm.ts
@@ -7,14 +7,8 @@ import { useCurrentSurveys } from "../../../contexts/current-surveys-context";
 import { useHospitalContext } from "../../../contexts/hospital-context";
 import useReadOnlyAccess from "./useReadOnlyAccess";
 import { useCurrentModule } from "../../../contexts/current-module-context";
-import {
-    Code,
-    Question,
-    isAntibioticQuestion,
-    isSpeciesQuestion,
-} from "../../../../domain/entities/Questionnaire/QuestionnaireQuestion";
+import { Code, Question } from "../../../../domain/entities/Questionnaire/QuestionnaireQuestion";
 import { Id } from "../../../../domain/entities/Ref";
-import { useASTGuidelinesOptions } from "../../../hooks/useASTGuidelinesOptions";
 
 export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | undefined) {
     const { compositionRoot, currentUser } = useAppContext();
@@ -31,7 +25,6 @@ export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | und
         currentFacilityLevelForm,
     } = useCurrentSurveys();
     const { hasReadOnlyAccess } = useReadOnlyAccess();
-    const { getAntibioticOptions, getSpeciesQuestionForAntibiotic } = useASTGuidelinesOptions();
 
     const [error, setError] = useState<string>();
     const { currentModule } = useCurrentModule();
@@ -158,28 +151,15 @@ export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | und
     const updateQuestion = useCallback(
         (question: Question, stageId?: string) => {
             if (questionnaire) {
-                const corrspondingSpeciesQuestion =
-                    question.type === "select" && isAntibioticQuestion(question)
-                        ? getSpeciesQuestionForAntibiotic(question, questionnaire)
-                        : undefined;
-
-                const antibioticOptions =
-                    question.type === "select" && isSpeciesQuestion(question)
-                        ? getAntibioticOptions(question)
-                        : corrspondingSpeciesQuestion
-                        ? getAntibioticOptions(corrspondingSpeciesQuestion)
-                        : undefined;
-
                 const updatedQuestionnaire = Questionnaire.updateQuestionnaire(
                     questionnaire,
                     question,
-                    stageId,
-                    antibioticOptions
+                    stageId
                 );
                 setQuestionnaire(updatedQuestionnaire);
             }
         },
-        [getAntibioticOptions, getSpeciesQuestionForAntibiotic, questionnaire]
+        [questionnaire]
     );
 
     const addProgramStage = useCallback(

--- a/src/webapp/components/survey/hook/useSurveyForm.ts
+++ b/src/webapp/components/survey/hook/useSurveyForm.ts
@@ -148,19 +148,18 @@ export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | und
         currentModule,
     ]);
 
-    const updateQuestion = useCallback(
-        (question: Question, stageId?: string) => {
-            if (questionnaire) {
+    const updateQuestion = useCallback((question: Question, stageId?: string) => {
+        setQuestionnaire(prevQuestionniare => {
+            if (prevQuestionniare) {
                 const updatedQuestionnaire = Questionnaire.updateQuestionnaire(
-                    questionnaire,
+                    prevQuestionniare,
                     question,
                     stageId
                 );
-                setQuestionnaire(updatedQuestionnaire);
-            }
-        },
-        [questionnaire]
-    );
+                return updatedQuestionnaire;
+            } else return prevQuestionniare;
+        });
+    }, []);
 
     const addProgramStage = useCallback(
         (stageCode: Code) => {

--- a/src/webapp/hooks/useASTGuidelinesOptions.ts
+++ b/src/webapp/hooks/useASTGuidelinesOptions.ts
@@ -38,12 +38,7 @@ export function useASTGuidelinesOptions() {
             keyVal => question.value?.code && keyVal[1].includes(question.value.code)
         )?.[0];
 
-        if (matrixKey) {
-            const optionList = currentASTMatrix.get(matrixKey);
-            if (optionList) {
-                return optionList;
-            }
-        }
+        return matrixKey ? currentASTMatrix.get(matrixKey) : undefined;
     };
 
     const getSpeciesQuestionForAntibiotic = (

--- a/src/webapp/hooks/useASTGuidelinesOptions.ts
+++ b/src/webapp/hooks/useASTGuidelinesOptions.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useCurrentASTGuidelinesContext } from "../contexts/current-ast-guidelines-context";
 import { useCurrentSurveys } from "../contexts/current-surveys-context";
 import {
@@ -33,13 +33,16 @@ export function useASTGuidelinesOptions() {
         setCurrentASTMatrix(currentMatrix);
     }, [currentASTGuidelines, currentPrevalenceSurveyForm]);
 
-    const getAntibioticOptions = (question: SpeciesQuestion): string[] | undefined => {
-        const matrixKey = [...currentASTList].find(
-            keyVal => question.value?.code && keyVal[1].includes(question.value.code)
-        )?.[0];
+    const getAntibioticOptions = useCallback(
+        (question: SpeciesQuestion): string[] | undefined => {
+            const matrixKey = [...currentASTList].find(
+                keyVal => question.value?.code && keyVal[1].includes(question.value.code)
+            )?.[0];
 
-        return matrixKey ? currentASTMatrix.get(matrixKey) : undefined;
-    };
+            return matrixKey ? currentASTMatrix.get(matrixKey) : undefined;
+        },
+        [currentASTList, currentASTMatrix]
+    );
 
     const getSpeciesQuestionForAntibiotic = (
         question: AntibioticQuestion,

--- a/src/webapp/hooks/useASTGuidelinesOptions.ts
+++ b/src/webapp/hooks/useASTGuidelinesOptions.ts
@@ -1,14 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
 import { useCurrentASTGuidelinesContext } from "../contexts/current-ast-guidelines-context";
 import { useCurrentSurveys } from "../contexts/current-surveys-context";
-import {
-    AntibioticQuestion,
-    SpeciesQuestion,
-    isSpeciesQuestion,
-} from "../../domain/entities/Questionnaire/QuestionnaireQuestion";
-import { Questionnaire } from "../../domain/entities/Questionnaire/Questionnaire";
+import { SpeciesQuestion } from "../../domain/entities/Questionnaire/QuestionnaireQuestion";
 import _ from "../../domain/entities/generic/Collection";
-import { QuestionnaireSectionM } from "../../domain/entities/Questionnaire/QuestionnaireSection";
 
 export function useASTGuidelinesOptions() {
     const { currentASTGuidelines } = useCurrentASTGuidelinesContext();
@@ -44,20 +38,5 @@ export function useASTGuidelinesOptions() {
         [currentASTList, currentASTMatrix]
     );
 
-    const getSpeciesQuestionForAntibiotic = (
-        question: AntibioticQuestion,
-        questionnaire: Questionnaire
-    ): SpeciesQuestion | undefined => {
-        const currentStage = questionnaire.stages.find(stage => stage.id === question.stageId);
-
-        if (!currentStage) return undefined;
-        const speciesSection = QuestionnaireSectionM.getSpeciesSection(currentStage?.sections);
-
-        const speciesQuestion: SpeciesQuestion | undefined = speciesSection?.questions?.find(
-            q => q.type === "select" && isSpeciesQuestion(q)
-        ) as SpeciesQuestion;
-
-        return speciesQuestion;
-    };
-    return { getAntibioticOptions, getSpeciesQuestionForAntibiotic };
+    return { getAntibioticOptions };
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?https://app.clickup.com/t/8694ap44d
- https://app.clickup.com/t/8694ap48n
- 8694ap44d
- 8694ap48n

### :memo: Implementation
1. On species change, pre populate all antibiotic options in grid
2. handle AST Result or Value data entry
3. On reset of species, reset antibiotic details.

### :video_camera: Screenshots/Screen capture

https://github.com/EyeSeeTea/amr-surveys/assets/83749675/5d50d20c-19b5-4863-a5c6-d4bdc5b762a9



### :fire: Notes to the tester
