### PR TITLE
Prevalence patient search

### DIFF
--- a/src/data/repositories/testRepositories/PaginatedSurveyTestRepository.ts
+++ b/src/data/repositories/testRepositories/PaginatedSurveyTestRepository.ts
@@ -11,6 +11,12 @@ export class PaginatedSurveyTestRepository implements PaginatedSurveyRepository 
     ): FutureData<PaginatedReponse<Survey[]>> {
         throw new Error("Method not implemented.");
     }
+    getFilteredPrevalencePatientSurveys(
+        keyword: string,
+        orgUnitId: string
+    ): FutureData<PaginatedReponse<Survey[]>> {
+        throw new Error("Method not implemented.");
+    }
     getSurveys(
         surveyFormType: SURVEY_FORM_TYPES,
         programId: string,

--- a/src/data/utils/surveyNameHelper.ts
+++ b/src/data/utils/surveyNameHelper.ts
@@ -1,0 +1,48 @@
+import { Id } from "@eyeseetea/d2-api";
+import { SURVEY_FORM_TYPES } from "../../domain/entities/Survey";
+import { FutureData, apiToFuture } from "../api-futures";
+import { getSurveyType } from "./surveyProgramHelper";
+import { D2TrackerEvent } from "@eyeseetea/d2-api/api/trackerEvents";
+import {
+    PREVALENCE_SURVEY_NAME_DATAELEMENT_ID,
+    SURVEY_NAME_DATAELEMENT_ID,
+} from "../entities/D2Survey";
+import { Future } from "../../domain/entities/generic/Future";
+import { D2Api } from "@eyeseetea/d2-api/2.36";
+
+export const getSurveyNameFromId = (
+    id: Id,
+    surveyFormType: SURVEY_FORM_TYPES,
+    api: D2Api
+): FutureData<string> => {
+    const parentSurveyType = getSurveyType(surveyFormType);
+
+    return getEventProgramById(id, api)
+        .flatMap(survey => {
+            if (survey) {
+                if (parentSurveyType === "PPS") {
+                    const ppsSurveyName = survey.dataValues?.find(
+                        dv => dv.dataElement === SURVEY_NAME_DATAELEMENT_ID
+                    )?.value;
+                    return Future.success(ppsSurveyName ?? "");
+                } else {
+                    const prevalenceSurveyName = survey.dataValues?.find(
+                        dv => dv.dataElement === PREVALENCE_SURVEY_NAME_DATAELEMENT_ID
+                    )?.value;
+                    return Future.success(prevalenceSurveyName ?? "");
+                }
+            } else return Future.success("");
+        })
+        .flatMapError(_err => Future.success(""));
+};
+
+export const getEventProgramById = (eventId: Id, api: D2Api): FutureData<D2TrackerEvent | void> => {
+    return apiToFuture(
+        api.tracker.events.getById(eventId, {
+            fields: { $all: true },
+        })
+    ).flatMap(resp => {
+        if (resp) return Future.success(resp);
+        else return Future.success(undefined);
+    });
+};

--- a/src/domain/repositories/PaginatedSurveyRepository.ts
+++ b/src/domain/repositories/PaginatedSurveyRepository.ts
@@ -16,4 +16,8 @@ export interface PaginatedSurveyRepository {
         keyword: string,
         orgUnitId: Id
     ): FutureData<PaginatedReponse<Survey[]>>;
+    getFilteredPrevalencePatientSurveys(
+        keyword: string,
+        orgUnitId: Id
+    ): FutureData<PaginatedReponse<Survey[]>>;
 }

--- a/src/domain/usecases/GetFilteredPatientsUseCase.ts
+++ b/src/domain/usecases/GetFilteredPatientsUseCase.ts
@@ -1,13 +1,24 @@
 import { Id } from "@eyeseetea/d2-api";
 import { FutureData } from "../../data/api-futures";
-import { Survey } from "../entities/Survey";
+import { SURVEY_FORM_TYPES, Survey } from "../entities/Survey";
 import { PaginatedReponse } from "../entities/TablePagination";
 import { PaginatedSurveyRepository } from "../repositories/PaginatedSurveyRepository";
+import { Future } from "../entities/generic/Future";
 
 export class GetFilteredPatientsUseCase {
     constructor(private paginatedSurveyRepo: PaginatedSurveyRepository) {}
 
-    public execute(keyword: string, orgUnitId: Id): FutureData<PaginatedReponse<Survey[]>> {
-        return this.paginatedSurveyRepo.getFilteredPPSPatientSurveys(keyword, orgUnitId);
+    public execute(
+        keyword: string,
+        orgUnitId: Id,
+        surveyFormType: SURVEY_FORM_TYPES
+    ): FutureData<PaginatedReponse<Survey[]>> {
+        if (surveyFormType === "PPSPatientRegister") {
+            return this.paginatedSurveyRepo.getFilteredPPSPatientSurveys(keyword, orgUnitId);
+        } else if (surveyFormType === "PrevalenceCaseReportForm") {
+            return this.paginatedSurveyRepo.getFilteredPrevalencePatientSurveys(keyword, orgUnitId);
+        } else {
+            return Future.error(new Error("Unsupported survey form type"));
+        }
     }
 }

--- a/src/webapp/components/survey-list/SurveyList.tsx
+++ b/src/webapp/components/survey-list/SurveyList.tsx
@@ -82,10 +82,18 @@ export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
                             surveys
                         ) && (
                             <ButtonWrapper>
-                                {surveyFormType === "PPSPatientRegister" && (
+                                {["PPSPatientRegister", "PrevalenceCaseReportForm"].includes(
+                                    surveyFormType
+                                ) && (
                                     <TextField
                                         label={i18n.t("Search Patient")}
-                                        helperText={i18n.t("Filter by patient id or code")}
+                                        helperText={
+                                            surveyFormType === "PPSPatientRegister"
+                                                ? i18n.t("Filter by patient id or code")
+                                                : i18n.t(
+                                                      "Filter by survey id or unique survey patient id"
+                                                  )
+                                        }
                                         value={patientSearchKeyword}
                                         onChange={e => setPatientSearchKeyword(e.target.value)}
                                         onKeyDown={handleKeyPress}

--- a/src/webapp/components/survey-list/SurveyList.tsx
+++ b/src/webapp/components/survey-list/SurveyList.tsx
@@ -27,6 +27,12 @@ import useReadOnlyAccess from "../survey/hook/useReadOnlyAccess";
 interface SurveyListProps {
     surveyFormType: SURVEY_FORM_TYPES;
 }
+
+export const SURVEYS_WITH_FILTER_ENABLED: SURVEY_FORM_TYPES[] = [
+    "PPSPatientRegister",
+    "PrevalenceCaseReportForm",
+];
+
 export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
     const { currentPPSSurveyForm } = useCurrentSurveys();
     const { currentUser } = useAppContext();
@@ -82,9 +88,7 @@ export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
                             surveys
                         ) && (
                             <ButtonWrapper>
-                                {["PPSPatientRegister", "PrevalenceCaseReportForm"].includes(
-                                    surveyFormType
-                                ) && (
+                                {SURVEYS_WITH_FILTER_ENABLED.includes(surveyFormType) && (
                                     <TextField
                                         label={i18n.t("Search Patient")}
                                         helperText={

--- a/src/webapp/components/survey-list/hook/usePatientSearch.ts
+++ b/src/webapp/components/survey-list/hook/usePatientSearch.ts
@@ -4,6 +4,7 @@ import { useAppContext } from "../../../contexts/app-context";
 import { useCurrentSurveys } from "../../../contexts/current-surveys-context";
 import { useSnackbar } from "@eyeseetea/d2-ui-components";
 import i18n from "../../../../utils/i18n";
+import { SURVEYS_WITH_FILTER_ENABLED } from "../SurveyList";
 
 export const usePatientSearch = (
     filteredSurveys: Survey[] | undefined,
@@ -34,7 +35,7 @@ export const usePatientSearch = (
     const handleKeyPress = (event: React.KeyboardEvent<HTMLDivElement>) => {
         if (
             patientSearchKeyword &&
-            ["PPSPatientRegister", "PrevalenceCaseReportForm"].includes(surveyFormType) &&
+            SURVEYS_WITH_FILTER_ENABLED.includes(surveyFormType) &&
             event.key === "Enter"
         ) {
             setIsLoading(true);

--- a/src/webapp/components/survey-list/hook/usePatientSearch.ts
+++ b/src/webapp/components/survey-list/hook/usePatientSearch.ts
@@ -12,7 +12,7 @@ export const usePatientSearch = (
     setTotal: Dispatch<SetStateAction<number | undefined>>
 ) => {
     const { compositionRoot } = useAppContext();
-    const { currentHospitalForm } = useCurrentSurveys();
+    const { currentHospitalForm, currentFacilityLevelForm } = useCurrentSurveys();
     const snackbar = useSnackbar();
 
     const [patientSearchKeyword, setPatientSearchKeyword] = useState("");
@@ -34,12 +34,17 @@ export const usePatientSearch = (
     const handleKeyPress = (event: React.KeyboardEvent<HTMLDivElement>) => {
         if (
             patientSearchKeyword &&
-            surveyFormType === "PPSPatientRegister" &&
+            ["PPSPatientRegister", "PrevalenceCaseReportForm"].includes(surveyFormType) &&
             event.key === "Enter"
         ) {
             setIsLoading(true);
+            const orgUnitId =
+                surveyFormType === "PPSPatientRegister"
+                    ? currentHospitalForm?.orgUnitId || ""
+                    : currentFacilityLevelForm?.orgUnitId || "";
+
             compositionRoot.surveys.getFilteredPatients
-                .execute(patientSearchKeyword, currentHospitalForm?.orgUnitId ?? "")
+                .execute(patientSearchKeyword, orgUnitId, surveyFormType)
                 .run(
                     response => {
                         setSearchResultSurveys(response.objects);


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes#8694afm42 [Patient search in Prevalence module](https://app.clickup.com/t/8694afm42)

### :memo: Implementation

- Add Prevelance patient search logic. Since the trackedEntity endpoint doesn't support the rootJunction=OR, in order to filter by one field or the other, I've created two separate calls for each and joined them.

### :video_camera: Screenshots/Screen capture
<img width="1121" alt="image" src="https://github.com/EyeSeeTea/amr-surveys/assets/44171664/8da0f24b-7702-4201-b517-8280e6327497">


### :fire: Notes to the tester
