### PR TITLE
Error messages with names

### DIFF
--- a/src/data/repositories/SurveyFormD2Repository.ts
+++ b/src/data/repositories/SurveyFormD2Repository.ts
@@ -184,11 +184,11 @@ export class SurveyD2Repository implements SurveyRepository {
                             : result.bundleReport?.typeReportMap?.EVENT?.objectReports[0]?.uid;
                         return Future.success(surveyId);
                     } else {
-                        return Future.error(
-                            new Error(
-                                `Error: ${result?.validationReport?.errorReports?.at(0)?.message} `
-                            )
-                        );
+                        return this.getErrorMessageWithNames(
+                            result?.validationReport?.errorReports?.at(0)?.message
+                        ).flatMap(errorMessage => {
+                            return Future.error(new Error(`Error: ${errorMessage} `));
+                        });
                     }
                 });
             });
@@ -504,11 +504,11 @@ export class SurveyD2Repository implements SurveyRepository {
                 if (result && result.status !== "ERROR") {
                     return Future.success(undefined);
                 } else {
-                    return Future.error(
-                        new Error(
-                            `Error: ${result?.validationReport?.errorReports?.at(0)?.message} `
-                        )
-                    );
+                    return this.getErrorMessageWithNames(
+                        result?.validationReport?.errorReports?.at(0)?.message
+                    ).flatMap(errorMessage => {
+                        return Future.error(new Error(`Error: ${errorMessage} `));
+                    });
                 }
             });
         });
@@ -534,13 +534,128 @@ export class SurveyD2Repository implements SurveyRepository {
                 if (result && result.status !== "ERROR") {
                     return Future.success(undefined);
                 } else {
-                    return Future.error(
-                        new Error(
-                            `Error: ${result?.validationReport?.errorReports?.at(0)?.message} `
-                        )
-                    );
+                    return this.getErrorMessageWithNames(
+                        result?.validationReport?.errorReports?.at(0)?.message
+                    ).flatMap(errorMessage => {
+                        return Future.error(new Error(`Error: ${errorMessage} `));
+                    });
                 }
             });
         });
     }
+
+    private getErrorMessageWithNames(errMsg?: string): FutureData<string> {
+        if (!errMsg) return Future.success("");
+
+        let errorMessageWithNames = errMsg;
+
+        //DataElement: `{dataElementId}`
+        const dataElementPattern = /(?<=DataElement(:*) )`([A-Za-z0-9]{11})`/g;
+        const dataelementIds = dataElementPattern.exec(errMsg);
+
+        //Program: `{programId}`
+        const programPattern = /(?<=Program(:*) )`([A-Za-z0-9]{11})`/g;
+        const programIds = programPattern.exec(errMsg);
+
+        //OrgUnit: `{orgUnitId}`
+        const orgUnitPattern = /(?<=OrganisationUnit(:*) )`([A-Za-z0-9]{11})`/g;
+        const orgUnitIds = orgUnitPattern.exec(errMsg);
+
+        return this.fetchNames({
+            dataElementId: dataelementIds?.[2],
+            programId: programIds?.[2],
+            orgUnitId: orgUnitIds?.[2],
+        }).flatMap(({ dataElementName, programName, orgUnitName }) => {
+            if (dataelementIds && dataelementIds[2] && dataElementName) {
+                errorMessageWithNames = this.parseErrorMessage(
+                    errorMessageWithNames,
+                    dataelementIds[2],
+                    dataElementName
+                );
+            }
+
+            if (programIds && programIds[2] && programName) {
+                errorMessageWithNames = this.parseErrorMessage(
+                    errorMessageWithNames,
+                    programIds[2],
+                    programName
+                );
+            }
+
+            if (orgUnitIds && orgUnitIds[2] && orgUnitName) {
+                errorMessageWithNames = this.parseErrorMessage(
+                    errorMessageWithNames,
+                    orgUnitIds[2],
+                    orgUnitName
+                );
+            }
+
+            return Future.success(errorMessageWithNames);
+        });
+    }
+
+    private parseErrorMessage = (errMsg: string, id: string, name: string): string => {
+        return (
+            errMsg.slice(0, errMsg.indexOf(id) - 1) +
+            `${name} ` +
+            errMsg.slice(errMsg.indexOf(id) - 1)
+        );
+    };
+
+    private fetchNames = ({
+        dataElementId,
+        programId,
+        orgUnitId,
+    }: {
+        dataElementId?: Id;
+        programId?: Id;
+        orgUnitId?: Id;
+    }): FutureData<{
+        dataElementName?: string;
+        programName?: string;
+        orgUnitName?: string;
+    }> => {
+        if (!dataElementId && !programId && !orgUnitId) return Future.success({});
+
+        return apiToFuture(
+            this.api.metadata
+                .get({
+                    ...(dataElementId && {
+                        dataElements: {
+                            fields: { shortName: true },
+                            filter: { id: { eq: dataElementId } },
+                        },
+                    }),
+                    ...(programId && {
+                        programs: {
+                            fields: { shortName: true },
+                            filter: { id: { eq: programId } },
+                        },
+                    }),
+                    ...(orgUnitId && {
+                        organisationUnits: {
+                            fields: { shortName: true },
+                            filter: { id: { eq: orgUnitId } },
+                        },
+                    }),
+                })
+                .map(response => {
+                    const fetchedNames: {
+                        dataElementName?: string;
+                        programName?: string;
+                        orgUnitName?: string;
+                    } = {};
+                    if (response?.data?.dataElements) {
+                        fetchedNames.dataElementName = `${response.data.dataElements?.[0]?.shortName}`;
+                    }
+                    if (response?.data?.programs) {
+                        fetchedNames.programName = `${response.data.programs?.[0]?.shortName}`;
+                    }
+                    if (response?.data?.organisationUnits) {
+                        fetchedNames.orgUnitName = `${response.data.organisationUnits?.[0]?.shortName}`;
+                    }
+                    return fetchedNames;
+                })
+        );
+    };
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8693jgah5 [Parse IDs in error messages](https://app.clickup.com/t/8693jgah5)

### :memo: Implementation

- Parse dataElements, orgUnits & Program Id's in error messages, and get their short names to display on the error message.

### :video_camera: Screenshots/Screen capture
<img width="930" alt="image" src="https://github.com/EyeSeeTea/amr-surveys/assets/44171664/55b187ae-7dd8-45d4-b790-811099643c87">


### :fire: Notes to the tester
- Prevalence -> create new facility and add a orgUnit not matching with Program orgUnit
