### PR TITLE
Populate Survey id

### DIFF
--- a/src/data/utils/questionHelper.ts
+++ b/src/data/utils/questionHelper.ts
@@ -274,9 +274,19 @@ export const mapProgramDataElementToQuestions = (
                         currentQuestion.id === WARD2_ID_DATAELEMENT_ID ||
                         currentQuestion.id === AMR_SURVEYS_PREVALENCE_DEA_SURVEY_ID)
                 ) {
-                    currentQuestion.value = event?.event;
                     currentQuestion.disabled = true;
                 }
+
+                // Set SurveyId to the value of the eventId.
+                if (
+                    currentQuestion &&
+                    (currentQuestion.id === SURVEY_ID_DATAELEMENT_ID ||
+                        currentQuestion.id === SURVEY_ID_PATIENT_DATAELEMENT_ID ||
+                        currentQuestion.id === AMR_SURVEYS_PREVALENCE_DEA_SURVEY_ID)
+                ) {
+                    currentQuestion.value = event?.event;
+                }
+
                 return currentQuestion;
             }
         })

--- a/src/data/utils/questionHelper.ts
+++ b/src/data/utils/questionHelper.ts
@@ -274,6 +274,7 @@ export const mapProgramDataElementToQuestions = (
                         currentQuestion.id === WARD2_ID_DATAELEMENT_ID ||
                         currentQuestion.id === AMR_SURVEYS_PREVALENCE_DEA_SURVEY_ID)
                 ) {
+                    currentQuestion.value = event?.event;
                     currentQuestion.disabled = true;
                 }
                 return currentQuestion;
@@ -354,6 +355,7 @@ export const mapTrackedAttributesToQuestions = (
                     currentQuestion.id === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_SRL ||
                     currentQuestion.id === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_CRF)
             ) {
+                currentQuestion.value = trackedEntity?.trackedEntity;
                 currentQuestion.disabled = true;
             }
             return currentQuestion;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8694fg8tv [survey id not shown in survey form (at least in prevalence)](https://app.clickup.com/t/8694fg8tv)

### :memo: Implementation

- Add eventId or trackedEntityId to surveyId question.

### :video_camera: Screenshots/Screen capture
<img width="997" alt="image" src="https://github.com/EyeSeeTea/amr-surveys/assets/44171664/85ecb407-6156-48a5-9e49-20430848f920">


### :fire: Notes to the tester
