### PR TITLE
DateTime picker 24h instead of AM PM

### DIFF
--- a/src/webapp/components/survey-questions/widgets/DateTimePickerWidget.tsx
+++ b/src/webapp/components/survey-questions/widgets/DateTimePickerWidget.tsx
@@ -31,6 +31,7 @@ const DateTimePickerWidget: React.FC<DateTimePickerWidgetProps> = props => {
                 value={new Date(stateValue)}
                 disabled={props.disabled}
                 onChange={newValue => notifyChange(newValue?.toISOString() ?? "")}
+                ampm={false}
             />
         </LocalizationProvider>
     );


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes # [For day and time pickers convert them to 24h instead of AM/PM](https://app.clickup.com/t/8694grg6n)

### :memo: Implementation

- use datepicker flag to use 24h time

### :video_camera: Screenshots/Screen capture
<img width="907" alt="image" src="https://github.com/EyeSeeTea/amr-surveys/assets/44171664/34ebba7f-28c7-49a0-bac7-31de50a2816e">


### :fire: Notes to the tester
