### PR TITLE
show patient id column for all children of case report form

### DIFF
--- a/src/data/utils/surveyListMappers.ts
+++ b/src/data/utils/surveyListMappers.ts
@@ -11,6 +11,15 @@ import {
     SURVEY_ID_FACILITY_LEVEL_DATAELEMENT_ID,
     keyToDataElementMap,
     AMR_SURVEYS_PREVALENCE_TEA_UNIQUE_PATIENT_ID,
+    AMR_SURVEYS_PREVALENCE_TEA_PATIENT_ID,
+    AMR_SURVEYS_PREVALENCE_TEA_AMRPATIENT_IDPREVALENCE,
+    AMR_SURVEYS_PREVALENCE_TEA_PATIENT_IDA19,
+    AMR_SURVEYS_MORTALITY_TEA_PAT_ID_FUP2,
+    AMR_SURVEYS_MORTALITY_TEA_PAT_ID_DF2,
+    AMR_SURVEYS_MORTALITY_TEA_PAT_ID_COH2,
+    AMR_SURVEYS_MORTALITY_TEA_SURVEY_ID_FUP,
+    AMR_SURVEYS_MORTALITY_TEA_SURVEY_ID_DF,
+    AMR_SURVEYS_MORTALITY_TEA_SURVEY_ID_COH,
 } from "../entities/D2Survey";
 import { D2TrackerEvent } from "@eyeseetea/d2-api/api/trackerEvents";
 import { getSurveyNameBySurveyFormType } from "./surveyProgramHelper";
@@ -29,12 +38,22 @@ export const mapTrackedEntityToSurvey = (
                     attribute.attribute === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_CRL ||
                     attribute.attribute === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_PIS ||
                     attribute.attribute === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_SRL ||
-                    attribute.attribute === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_CRF
+                    attribute.attribute === AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_CRF ||
+                    attribute.attribute === AMR_SURVEYS_MORTALITY_TEA_SURVEY_ID_FUP ||
+                    attribute.attribute === AMR_SURVEYS_MORTALITY_TEA_SURVEY_ID_DF ||
+                    attribute.attribute === AMR_SURVEYS_MORTALITY_TEA_SURVEY_ID_COH
             )?.value ?? "";
 
         const patientId =
             trackedEntity.attributes?.find(
-                attribute => attribute.attribute === AMR_SURVEYS_PREVALENCE_TEA_UNIQUE_PATIENT_ID
+                attribute =>
+                    attribute.attribute === AMR_SURVEYS_PREVALENCE_TEA_UNIQUE_PATIENT_ID ||
+                    attribute.attribute === AMR_SURVEYS_PREVALENCE_TEA_PATIENT_ID ||
+                    attribute.attribute === AMR_SURVEYS_PREVALENCE_TEA_AMRPATIENT_IDPREVALENCE ||
+                    attribute.attribute === AMR_SURVEYS_PREVALENCE_TEA_PATIENT_IDA19 ||
+                    attribute.attribute === AMR_SURVEYS_MORTALITY_TEA_PAT_ID_FUP2 ||
+                    attribute.attribute === AMR_SURVEYS_MORTALITY_TEA_PAT_ID_DF2 ||
+                    attribute.attribute === AMR_SURVEYS_MORTALITY_TEA_PAT_ID_COH2
             )?.value ?? "";
 
         const survey: Survey = {

--- a/src/webapp/components/survey-list/table/PaginatedSurveyListTable.tsx
+++ b/src/webapp/components/survey-list/table/PaginatedSurveyListTable.tsx
@@ -27,6 +27,7 @@ import { ContentLoader } from "../../content-loader/ContentLoader";
 import { useSurveyListActions } from "../hook/useSurveyListActions";
 import { getChildrenName } from "../../../../domain/utils/getChildrenName";
 import { useMultipleChildCount } from "../hook/useMultipleChildCount";
+import { isPrevalencePatientChild } from "../../../../domain/utils/PPSProgramsHelper";
 
 interface PaginatedSurveyListTableProps {
     surveys: Survey[] | undefined;
@@ -112,7 +113,8 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                                     </TableCell>
 
                                     {(surveyFormType === "PPSPatientRegister" ||
-                                        surveyFormType === "PrevalenceCaseReportForm") && (
+                                        surveyFormType === "PrevalenceCaseReportForm" ||
+                                        isPrevalencePatientChild(surveyFormType)) && (
                                         <TableCell
                                             onClick={() => {
                                                 patientIdSortDirection === "asc"
@@ -197,7 +199,8 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                                         <TableRow key={survey.id}>
                                             <TableCell>{`${survey.rootSurvey.name}`}</TableCell>
                                             {(surveyFormType === "PPSPatientRegister" ||
-                                                surveyFormType === "PrevalenceCaseReportForm") && (
+                                                surveyFormType === "PrevalenceCaseReportForm" ||
+                                                isPrevalencePatientChild(surveyFormType)) && (
                                                 <TableCell>{survey.uniquePatient?.id}</TableCell>
                                             )}
                                             {surveyFormType === "PPSPatientRegister" && (


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #? https://app.clickup.com/t/8694hemdy
- 8694hemdy

### :memo: Implementation
1. For all children of case report form, show patient id coulmn.

### :video_camera: Screenshots/Screen capture
Couple of examples : 
<img width="1728" alt="Screenshot 2024-05-21 at 12 16 34 PM" src="https://github.com/EyeSeeTea/amr-surveys/assets/83749675/742ac388-56b4-42ae-bd32-782dbd328be3">
<img width="1728" alt="Screenshot 2024-05-21 at 12 17 11 PM" src="https://github.com/EyeSeeTea/amr-surveys/assets/83749675/f83c946d-e27f-4db0-8a91-692a39117076">


### :fire: Notes to the tester
