### PR TITLE
fix: fix order of fields for event programs

### DIFF
--- a/src/data/repositories/SurveyFormD2Repository.ts
+++ b/src/data/repositories/SurveyFormD2Repository.ts
@@ -27,7 +27,7 @@ import {
     AMR_SURVEYS_PREVALENCE_DEA_CUSTOM_AST_GUIDE,
     AMR_SURVEYS_PREVALENCE_DEA_AST_GUIDELINES,
 } from "../entities/D2Survey";
-import { ProgramMetadata } from "../entities/D2Program";
+import { ProgramDataElement, ProgramMetadata } from "../entities/D2Program";
 import {
     mapProgramToQuestionnaire,
     mapQuestionnaireToEvent,
@@ -56,6 +56,16 @@ export class SurveyD2Repository implements SurveyRepository {
             if (resp.programs[0]) {
                 const programDataElements = resp.programStageDataElements.map(
                     psde => psde.dataElement
+                );
+                const dataElementsWithSortOrder: ProgramDataElement[] = resp.dataElements.map(
+                    de => {
+                        return {
+                            ...de,
+                            sortOrder: resp.programStageDataElements.find(
+                                psde => psde.dataElement.id === de.id
+                            )?.sortOrder,
+                        };
+                    }
                 );
 
                 const sortedTrackedentityAttr = resp.programTrackedEntityAttributes
@@ -90,7 +100,7 @@ export class SurveyD2Repository implements SurveyRepository {
                                             undefined,
                                             trackedEntity,
                                             programDataElements,
-                                            resp.dataElements,
+                                            dataElementsWithSortOrder,
                                             sortedOptions,
                                             resp.programStages,
                                             resp.programStageSections,
@@ -116,7 +126,7 @@ export class SurveyD2Repository implements SurveyRepository {
                                         event,
                                         undefined,
                                         programDataElements,
-                                        resp.dataElements,
+                                        dataElementsWithSortOrder,
                                         resp.options,
                                         resp.programStages,
                                         resp.programStageSections,
@@ -140,7 +150,7 @@ export class SurveyD2Repository implements SurveyRepository {
                             undefined,
                             undefined,
                             programDataElements,
-                            resp.dataElements,
+                            dataElementsWithSortOrder,
                             resp.options,
                             resp.programStages,
                             resp.programStageSections,

--- a/src/data/utils/questionHelper.ts
+++ b/src/data/utils/questionHelper.ts
@@ -281,6 +281,7 @@ export const mapProgramDataElementToQuestions = (
         })
     )
         .compact()
+        .sortBy(q => q.sortOrder)
         .value();
 
     return questions;

--- a/src/webapp/components/survey-questions/QuestionWidget.tsx
+++ b/src/webapp/components/survey-questions/QuestionWidget.tsx
@@ -6,7 +6,6 @@ import TextWidget from "./widgets/TextWidget";
 import YesNoWidget from "./widgets/YesNoWidget";
 import DatePickerWidget from "./widgets/DatePickerWidget";
 import { Maybe, assertUnreachable } from "../../../utils/ts-utils";
-import DropdownSelectWidget from "./widgets/DropdownSelectWidget";
 import DateTimePickerWidget from "./widgets/DateTimePickerWidget";
 import SearchableSelect from "./widgets/SearchableSelect";
 import {
@@ -28,18 +27,7 @@ export const QuestionWidget: React.FC<QuestionWidgetProps> = React.memo(props =>
 
     switch (type) {
         case "select": {
-            if (question.options.length > 5 && question.options.length < 10) {
-                return (
-                    <DropdownSelectWidget
-                        value={question.value?.id}
-                        options={question.options}
-                        onChange={(value: Maybe<QuestionOption>) =>
-                            onChange(update(question, value))
-                        }
-                        disabled={disabled}
-                    />
-                );
-            } else if (question.options.length > 10) {
+            if (question.options.length > 5) {
                 return (
                     <SearchableSelect
                         value={question.options.find(op => op.id === question.value?.id) || null}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?https://app.clickup.com/t/8694grcdn
- 8694grcdn

### :memo: Implementation
apply sort order for event program fields.

### :video_camera: Screenshots/Screen capture
<img width="1728" alt="Screenshot 2024-05-21 at 11 21 34 PM" src="https://github.com/EyeSeeTea/amr-surveys/assets/83749675/1597c27f-265e-4c7e-ad72-cd40b87ec472">

### :fire: Notes to the tester
