### PR TITLE
feat: hide program stage based on datastore survey rule

### DIFF
--- a/src/domain/entities/AMRSurveyModule.ts
+++ b/src/domain/entities/AMRSurveyModule.ts
@@ -4,7 +4,7 @@ export type SURVEY_TYPE = "NationalSurvey" | "HospitalSurvey" | "SupranationalSu
 
 type UserGroups = { captureAccess: NamedRef[]; readAccess: NamedRef[]; adminAccess: NamedRef[] };
 
-type SurveyRuleType = "HIDEFIELD" | "HIDESECTION";
+type SurveyRuleType = "HIDEFIELD" | "HIDESECTION" | "HIDESTAGE";
 
 type Rule = {
     id: Id;

--- a/src/domain/entities/Questionnaire/Questionnaire.ts
+++ b/src/domain/entities/Questionnaire/Questionnaire.ts
@@ -174,6 +174,9 @@ export class Questionnaire {
         const updatedStages = questionnaire.stages.map(stage => {
             return {
                 ...stage,
+                isVisible: !surveyRule.rules.find(rule =>
+                    rule.toHide?.find(ruleStage => ruleStage === stage.id)
+                ),
                 sections: stage.sections.map(section => {
                     const currentSectionRule = surveyRule.rules.find(rule =>
                         rule.toHide?.find(de => de === section.code)
@@ -207,6 +210,29 @@ export class Questionnaire {
             questionnaire,
             updatedStages
         );
+
+        const hideEntityQuestionRule = surveyRule.rules.find(
+            rule =>
+                rule.type === "HIDEFIELD" &&
+                rule.toHide.find(id =>
+                    updatedQuestionnaire.entity?.questions.find(q => q.id === id)
+                )
+        );
+        if (hideEntityQuestionRule && questionnaire.entity) {
+            const updatedEntityQuestions: Question[] = questionnaire.entity.questions.map(
+                question => {
+                    return {
+                        ...question,
+                        isVisible: hideEntityQuestionRule.toHide.find(id => id === question.id)
+                            ? false
+                            : true,
+                    };
+                }
+            );
+
+            const updatedEntity = { ...questionnaire.entity, questions: updatedEntityQuestions };
+            return Questionnaire.updateQuestionnaireEntity(updatedQuestionnaire, updatedEntity);
+        }
 
         return updatedQuestionnaire;
     }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?https://app.clickup.com/t/8694jeq7p
- 8694jeq7p

### :memo: Implementation
1. Hide stage based on datastore survey rule

The following datastore setting, hides "Type of Care" field, "Coordinator1" section and "Hospital data" stage in Prevalence Facility-level form for "Mortality Test" Prevalence Survey Form with Id "PS9eOV6hAKn"
```
"rulesBySurvey": [
      {
        "surveyId": "PS9eOV6hAKn",
        "surveyRules": [
          {
            "formId": "m404pwBZ4YT",
            "rules": [
              {
                "id": "1",
                "toHide": [
                  "qSaS0DuwNiP"
                ],
                "type": "HIDEFIELD"
              },
              {
                "id": "2",
                "toHide": [
                  "O8Y14hlUvwI"
                ],
                "type": "HIDESECTION"
              },
              {
                "id": "2",
                "toHide": [
                  "a6EjeCKWus4"
                ],
                "type": "HIDESTAGE"
              }
            ]
          }
        ]
      }
    ]
```


### :video_camera: Screenshots/Screen capture

https://github.com/EyeSeeTea/amr-surveys/assets/83749675/ab0cf442-ccab-49f3-8f8f-bb5aadc7a5a3


### :fire: Notes to the tester
