### PR TITLE
fix : antiobiotc history order and program rule fix

### DIFF
--- a/src/data/repositories/SurveyFormD2Repository.ts
+++ b/src/data/repositories/SurveyFormD2Repository.ts
@@ -57,16 +57,36 @@ export class SurveyD2Repository implements SurveyRepository {
                 const programDataElements = resp.programStageDataElements.map(
                     psde => psde.dataElement
                 );
-                const dataElementsWithSortOrder: ProgramDataElement[] = resp.dataElements.map(
-                    de => {
-                        return {
-                            ...de,
-                            sortOrder: resp.programStageDataElements.find(
-                                psde => psde.dataElement.id === de.id
-                            )?.sortOrder,
-                        };
-                    }
-                );
+
+                const dataElementsWithSortOrder: ProgramDataElement[] = resp.programStageSections
+                    ? resp.programStageSections.flatMap(section => {
+                          const sortedSectionDataElements: ProgramDataElement[] = _(
+                              section.dataElements.map((sectionDataElement, index) => {
+                                  const currentDataElement: ProgramDataElement | undefined =
+                                      resp.dataElements.find(de => de.id === sectionDataElement.id);
+
+                                  if (!currentDataElement) return null;
+                                  const sectionDataElementWithSortOrder: ProgramDataElement = {
+                                      ...currentDataElement,
+                                      sortOrder: index,
+                                  };
+
+                                  return sectionDataElementWithSortOrder;
+                              })
+                          )
+                              .compact()
+                              .value();
+
+                          return sortedSectionDataElements;
+                      })
+                    : resp.dataElements.map(de => {
+                          return {
+                              ...de,
+                              sortOrder: resp.programStageDataElements.find(
+                                  psde => psde.dataElement.id === de.id
+                              )?.sortOrder,
+                          };
+                      });
 
                 const sortedTrackedentityAttr = resp.programTrackedEntityAttributes
                     ? _(

--- a/src/domain/entities/Questionnaire/QuestionnaireRules.ts
+++ b/src/domain/entities/Questionnaire/QuestionnaireRules.ts
@@ -244,7 +244,7 @@ export const parseCondition = (
     // Split condition into sub-conditions based on logical operators
     const andConditions = newCondition.split("&&").map(subCondition1 => {
         const orConditions = subCondition1.split("||").map(subCondition2 => {
-            const notCondition = subCondition2.trim().startsWith("!");
+            const notCondition = subCondition2.trim().replace("(", "").startsWith("!");
             const trimmedSubCondition = notCondition
                 ? subCondition2.trim().substring(1)
                 : subCondition2;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8694nyekv, #8694nyekv    
-   https://app.clickup.com/t/8694nyekv, https://app.clickup.com/t/8694nyekv

### :memo: Implementation
1. Fix order of questions for program stages with sections.
2. Fix program rule parsing for not condition inside parenthesis. 

### :video_camera: Screenshots/Screen capture

https://github.com/EyeSeeTea/amr-surveys/assets/83749675/790da705-46f7-44bb-b30f-0d0a0d8483ac
https://github.com/EyeSeeTea/amr-surveys/assets/83749675/4384bbe8-5099-4881-8e4c-2075cb74de3d

### IMPORTANT NOTE : METADATA CHANGES
the program rule condition had an extra parenthesis () around condition : (#{AMR_CRF_PRV_IF_NO_INDICATE_PERIOD_BETWEEN_SAMPLING_LAST_AB_TAKE})
We need to remove this. Updated program rule : https://dev.eyeseetea.com/who-dev-238/api/programRules/cdplJvEChSz.json

### :fire: Notes to the tester
