### PR TITLE
clear field option change - intermediate fix

### DIFF
--- a/src/domain/entities/Questionnaire/QuestionnaireQuestion.ts
+++ b/src/domain/entities/Questionnaire/QuestionnaireQuestion.ts
@@ -193,8 +193,29 @@ export class QuestionnaireQuestion {
 
             return parsedAndUpdatedQuestion;
         });
+        //If any of the updated question has been changed to hidden, then reset its value
+        //When it is shown again, the user can enter a "fresh" value
+        const hiddenQuestions = parsedAndUpdatedQuestions.filter(
+            q =>
+                q.isVisible === false &&
+                updatedQuestions.find(uq => uq.id === q.id)?.isVisible === true
+        );
 
-        return _(parsedAndUpdatedQuestions)
+        if (hiddenQuestions.length === 0)
+            return _(parsedAndUpdatedQuestions)
+                .sortBy(question => question.sortOrder)
+                .value();
+
+        const resetQuestions = hiddenQuestions.reduce((acc, hiddenQuestion) => {
+            return this.updateQuestions(
+                acc,
+                { ...hiddenQuestion, value: undefined },
+                rules,
+                questionnaire
+            );
+        }, parsedAndUpdatedQuestions);
+
+        return _(resetQuestions)
             .sortBy(question => question.sortOrder)
             .value();
     }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #https://app.clickup.com/t/869569t5u, #869569t5u

### :memo: Implementation
1. When questions are hidden as side effect of another question update, reset their values

IMPORTANT NOTE : 
Following metadata change is required to program rule : 
https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/programSection/programRule/cdplJvEChSz
Hide field "Add another one"
<img width="1728" alt="Screenshot 2024-08-02 at 12 58 12 PM" src="https://github.com/user-attachments/assets/0db6a089-93c0-4406-a494-db4cfb683511">
 

### :video_camera: Screenshots/Screen capture

Uploading ResetFieldsOnNo-Intermediate.mov…


### :fire: Notes to the tester
