### PR TITLE
fix: paginated child count + sync save

### DIFF
--- a/src/data/repositories/SurveyFormD2Repository.ts
+++ b/src/data/repositories/SurveyFormD2Repository.ts
@@ -199,30 +199,25 @@ export class SurveyD2Repository implements SurveyRepository {
             : mapQuestionnaireToEvent(questionnaire, orgUnitId, programId, this.api, eventId);
 
         return $payload.flatMap(payload => {
-            return apiToFuture(
-                this.api.tracker.postAsync({ importStrategy: action }, payload)
-            ).flatMap(response => {
-                return apiToFuture(
-                    // eslint-disable-next-line testing-library/await-async-utils
-                    this.api.system.waitFor("TRACKER_IMPORT_JOB", response.response.id)
-                ).flatMap(result => {
-                    if (result && result.status !== "ERROR") {
+            return apiToFuture(this.api.tracker.post({ importStrategy: action }, payload)).flatMap(
+                response => {
+                    if (response && response.status !== "ERROR") {
                         //return the saved survey id.
 
                         const surveyId = isTrackerProgram(programId)
-                            ? result.bundleReport?.typeReportMap?.TRACKED_ENTITY?.objectReports[0]
+                            ? response.bundleReport?.typeReportMap?.TRACKED_ENTITY?.objectReports[0]
                                   ?.uid
-                            : result.bundleReport?.typeReportMap?.EVENT?.objectReports[0]?.uid;
+                            : response.bundleReport?.typeReportMap?.EVENT?.objectReports[0]?.uid;
                         return Future.success(surveyId);
                     } else {
                         return this.getErrorMessageWithNames(
-                            result?.validationReport?.errorReports?.at(0)?.message
+                            response?.validationReport?.errorReports?.at(0)?.message
                         ).flatMap(errorMessage => {
                             return Future.error(new Error(`Error: ${errorMessage} `));
                         });
                     }
-                });
-            });
+                }
+            );
         });
     }
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/86961vz1t, #86961vz1t
- https://app.clickup.com/t/869689u3g, #869689u3g

### :memo: Implementation
1. Save forms synchronously
2. Fetch child counts with pagination

### :video_camera: Screenshots/Screen capture
<img width="1728" alt="Screenshot 2024-10-23 at 10 40 06 AM" src="https://github.com/user-attachments/assets/5a44bff3-b28d-4751-995f-521382e2a292">

### :fire: Notes to the tester
