### PR TITLE
feat: move add another treatment button to the bottom of section

### DIFF
--- a/src/webapp/components/survey/SurveyForm.tsx
+++ b/src/webapp/components/survey/SurveyForm.tsx
@@ -116,25 +116,7 @@ export const SurveyForm: React.FC<SurveyFormProps> = props => {
                     return (
                         <PaddedDiv key={stage.id}>
                             <Typography>{i18n.t(`Stage - ${stage.title}`)}</Typography>
-                            {stage.repeatable && (
-                                <RightAlignedDiv>
-                                    <Button
-                                        variant="contained"
-                                        color="primary"
-                                        onClick={() => addProgramStage(stage.code)}
-                                    >
-                                        {i18n.t(`Add Another ${stage.title}`)}
-                                    </Button>
-                                    {stage.isAddedByUser && (
-                                        <CancelButton
-                                            variant="outlined"
-                                            onClick={() => removeProgramStage(stage.id)}
-                                        >
-                                            {i18n.t(`Remove ${stage.title}`)}
-                                        </CancelButton>
-                                    )}
-                                </RightAlignedDiv>
-                            )}
+
                             {stage.sections.map(section => {
                                 if (!section.isVisible || section.isAntibioticSection) return null;
 
@@ -172,6 +154,26 @@ export const SurveyForm: React.FC<SurveyFormProps> = props => {
                                     />
                                 );
                             })}
+
+                            {stage.repeatable && (
+                                <RightAlignedDiv>
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        onClick={() => addProgramStage(stage.code)}
+                                    >
+                                        {i18n.t(`Add Another ${stage.title}`)}
+                                    </Button>
+                                    {stage.isAddedByUser && (
+                                        <CancelButton
+                                            variant="outlined"
+                                            onClick={() => removeProgramStage(stage.id)}
+                                        >
+                                            {i18n.t(`Remove ${stage.title}`)}
+                                        </CancelButton>
+                                    )}
+                                </RightAlignedDiv>
+                            )}
                         </PaddedDiv>
                     );
                 })}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/86971bu93

### :memo: Implementation
- [x] Move repeat stage button to the bottom of the section

### :video_camera: Screenshots/Screen capture
<img width="1438" alt="Screenshot 2024-12-12 at 21 34 40" src="https://github.com/user-attachments/assets/b26054f4-cbab-47cd-8df3-49eed12bfb94" />

### :fire: Notes to the tester

#86971bu93