### PR TITLE
fix: Indefinite spinner on save survey form error

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,11 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-05-23T16:02:03.207Z\n"
-"PO-Revision-Date: 2024-05-23T16:02:03.207Z\n"
+"POT-Creation-Date: 2024-12-20T16:08:06.715Z\n"
+"PO-Revision-Date: 2024-12-20T16:08:06.715Z\n"
+
+msgid "There was an error processing the form"
+msgstr ""
 
 msgid "Facilities"
 msgstr ""

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,12 +1,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-05-22T13:24:01.336Z\n"
+"POT-Creation-Date: 2024-12-20T16:08:06.715Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
+
+msgid "There was an error processing the form"
+msgstr ""
 
 msgid "Facilities"
 msgstr ""

--- a/src/data/utils/questionHelper.ts
+++ b/src/data/utils/questionHelper.ts
@@ -38,6 +38,7 @@ import {
 import _ from "../../domain/entities/generic/Collection";
 import { D2TrackerEvent } from "@eyeseetea/d2-api/api/trackerEvents";
 import { D2TrackerTrackedEntity as TrackedEntity } from "@eyeseetea/d2-api/api/trackerTrackedEntities";
+import { isValidDate } from "../../utils/dates";
 
 const SPECIES_QUESTION_FORNAME = "Specify the specie";
 const ANTIBIOTIC_QUESTION_FORNAME = "Specify the antibiotic";
@@ -173,7 +174,7 @@ export const getQuestion = (
             const dateQ: DateQuestion = {
                 ...base,
                 type: "date",
-                value: dataValue ? new Date(dataValue) : undefined,
+                value: parseQuestionDate(dataValue, base),
             };
             return dateQ;
         }
@@ -182,11 +183,23 @@ export const getQuestion = (
             const dateQ: DateTimeQuestion = {
                 ...base,
                 type: "datetime",
-                value: dataValue ? new Date(dataValue) : undefined,
+                value: parseQuestionDate(dataValue, base),
             };
             return dateQ;
         }
     }
+};
+
+const parseQuestionDate = (
+    dateStr: string | undefined,
+    question: QuestionBase
+): Date | undefined => {
+    if (!dateStr) return undefined;
+    const result = isValidDate(new Date(dateStr)) ? new Date(dateStr) : undefined;
+    if (dateStr && !result) {
+        console.debug(`Invalid date value: ${dateStr}`, question);
+    }
+    return result;
 };
 
 export const mapQuestionsToDataValues = (questions: Question[]): DataValue[] => {

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,0 +1,1 @@
+export const isValidDate = (date: Date): boolean => !Number.isNaN(date.getTime());

--- a/src/webapp/components/survey/SurveyForm.tsx
+++ b/src/webapp/components/survey/SurveyForm.tsx
@@ -67,14 +67,14 @@ export const SurveyForm: React.FC<SurveyFormProps> = props => {
 
         if (saveCompleteState && saveCompleteState.status === "error") {
             snackbar.error(saveCompleteState.message);
-            if (props.hideForm) props.hideForm();
+            setLoading(false);
         }
 
         //If error fetching survey, redirect to homepage.
         if (error) {
             history.push(`/`);
         }
-    }, [error, saveCompleteState, snackbar, history, props]);
+    }, [error, saveCompleteState, snackbar, history, props, setLoading]);
 
     const saveSurveyForm = () => {
         setLoading(true);


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8696xt3f5 #8696xt3f5

### :memo: Implementation

- Submit Error Handling in `SurveyForm`: in case of an error, the loading state is now set to false, and the user remains in the form page instead of being redirected.
- Invalid Dates: invalid dates from the server are treated as undefined and unset. They will be unset when the form is saved.
- Added try/catch blocks to ensure errors during mapping are caught and handled

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/585708d9-1bfb-4033-8dac-92bfc0d960a1

### :fire: Notes to the tester

- I discovered that the `"DATE_TIME_KNOWN"` string is being used in the program rule `dvlWCs6iKLF`.  
- It may be important to investigate this specific case to ensure that overriding this value to `undefined` doesn't cause unintended issues. If needed, specific handling might have to be added, as this scenario may not have been previously accounted for.