### PR TITLE
feat: Add support for ASSIGN actions in Program Rules

### DIFF
--- a/src/data/entities/D2ExpressionParser.ts
+++ b/src/data/entities/D2ExpressionParser.ts
@@ -12,23 +12,41 @@ export class D2ExpressionParser {
                 ruleCondition,
                 xp.ExpressionMode.RULE_ENGINE_CONDITION
             );
-
-            const ruleVariables = this.mapProgramRuleVariables(expressionParser, variableValues);
-            const genericVariables = this.mapProgramVariables(expressionParser);
-            const variables = new Map([...ruleVariables, ...genericVariables]);
-
-            const expressionData = new xp.ExpressionDataJs(variables);
-
-            const parsedResult: boolean = expressionParser.evaluate(
-                () => console.debug(""),
-                expressionData
-            );
-
+            const expressionData = this.getExpressionDataJs(expressionParser, variableValues);
+            const parsedResult: boolean = expressionParser.evaluate(() => {}, expressionData);
             return Either.success(parsedResult);
         } catch (error) {
             return Either.error(error as Error);
         }
     }
+
+    public evaluateActionExpression(
+        expression: string,
+        variableValues: Map<ProgramRuleVariableName, ProgramRuleVariableValue>
+    ): Either<Error, EvaluatedExpressionResult> {
+        try {
+            const expressionParser = new xp.ExpressionJs(
+                expression,
+                xp.ExpressionMode.RULE_ENGINE_ACTION
+            );
+            const expressionData = this.getExpressionDataJs(expressionParser, variableValues);
+            const parsedResult: EvaluatedExpressionResult = expressionParser.evaluate(() => {},
+            expressionData);
+            return Either.success(parsedResult);
+        } catch (error) {
+            return Either.error(error as Error);
+        }
+    }
+
+    private getExpressionDataJs = (
+        expressionParser: xp.ExpressionJs,
+        variableValues: Map<ProgramRuleVariableName, ProgramRuleVariableValue>
+    ): xp.ExpressionDataJs => {
+        const ruleVariables = this.mapProgramRuleVariables(expressionParser, variableValues);
+        const genericVariables = this.mapProgramVariables(expressionParser);
+        const variables = new Map([...ruleVariables, ...genericVariables]);
+        return new xp.ExpressionDataJs(variables);
+    };
 
     private getVariableValueByType = (
         type: ProgramRuleVariableType,
@@ -106,3 +124,5 @@ const VariableValueTypeMap: Record<ProgramRuleVariableType, xp.ValueType> = {
     date: xp.ValueType.DATE,
     number: xp.ValueType.NUMBER,
 };
+
+export type EvaluatedExpressionResult = boolean | string | number | Date | null;

--- a/src/domain/entities/Questionnaire/QuestionnaireQuestion.ts
+++ b/src/domain/entities/Questionnaire/QuestionnaireQuestion.ts
@@ -1,6 +1,10 @@
 import { Maybe, assertUnreachable } from "../../../utils/ts-utils";
 import { Id, NamedRef } from "../Ref";
-import { getApplicableRules, QuestionnaireRule } from "./QuestionnaireRules";
+import {
+    getApplicableRules,
+    getQuestionValueFromEvaluatedExpression,
+    QuestionnaireRule,
+} from "./QuestionnaireRules";
 import _ from "../generic/Collection";
 import { Questionnaire } from "./Questionnaire";
 
@@ -267,16 +271,69 @@ export class QuestionnaireQuestion {
         return finalUpdatesWithSideEffects;
     }
 
-    private static updateQuestion(question: Question, rules: QuestionnaireRule[]): Question {
+    private static updateQuestion<T extends Question>(question: T, rules: QuestionnaireRule[]): T {
         const updatedIsVisible = this.isQuestionVisible(question, rules);
         const updatedErrors = this.getQuestionWarningsAndErrors(question, rules);
-
+        const updatedIsDisabled = this.isQuestionDisabled(question, rules);
+        const updatedValue = this.getQuestionAssignValue(question, rules);
         return {
             ...question,
             isVisible: updatedIsVisible,
             errors: updatedErrors,
+            disabled: updatedIsDisabled,
+            value: updatedValue,
             ...(question.isVisible !== updatedIsVisible ? { value: undefined } : {}),
         };
+    }
+
+    private static getRulesWithAssignActionForQuestion(
+        question: Question,
+        rules: QuestionnaireRule[]
+    ) {
+        return rules.filter(
+            rule =>
+                rule.parsedResult &&
+                rule.actions.filter(
+                    action =>
+                        action.programRuleActionType === "ASSIGN" &&
+                        ((action.dataElement && action.dataElement.id === question.id) ||
+                            (action.trackedEntityAttribute &&
+                                action.trackedEntityAttribute.id === question.id))
+                ).length > 0
+        );
+    }
+
+    private static isQuestionDisabled(
+        question: Question,
+        rules: QuestionnaireRule[]
+    ): boolean | undefined {
+        const applicableRules = this.getRulesWithAssignActionForQuestion(question, rules);
+        return applicableRules.length > 0 ? true : question.disabled;
+    }
+
+    private static getQuestionAssignValue(
+        question: Question,
+        rules: QuestionnaireRule[]
+    ): Question["value"] {
+        const applicableActions = this.getRulesWithAssignActionForQuestion(question, rules).flatMap(
+            rule => rule.actions
+        );
+        if (applicableActions.length === 0) {
+            return question.value;
+        } else {
+            if (applicableActions.length > 1) {
+                console.warn(
+                    "Multiple ASSIGN actions found for question: ",
+                    question,
+                    "Applying first rule:",
+                    applicableActions[0]
+                );
+            }
+            return getQuestionValueFromEvaluatedExpression(
+                question,
+                applicableActions[0]?.dataEvaluated
+            );
+        }
     }
 
     private static isQuestionVisible(question: Question, rules: QuestionnaireRule[]): boolean {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8696w4136 #8696w4136

### :memo: Implementation

- Disable the fields targeted by an assign action (tracker capture app does the same)
- Use D2ExpressionParser to evaluate the expression used in the action data
- Set the target field values according to the evaluated assign action data

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/58211b58-e14e-4063-842a-dedd9539b7f5

### 🔥 Notes to the tester

- While this PR provides generic support for assign actions, I only tested it with the program rule mentioned in the issue
