### PR TITLE
Fix: Propagate program rules execution after assign actions

### DIFF
--- a/src/domain/entities/Questionnaire/Questionnaire.ts
+++ b/src/domain/entities/Questionnaire/Questionnaire.ts
@@ -79,6 +79,17 @@ export class Questionnaire {
         return this.data.subLevelDetails;
     }
 
+    /** Returns all questions, including entity questions and stage questions */
+    getAllQuestions(): Question[] {
+        const stageQuestions = this.stages.flatMap((stage: QuestionnaireStage) => {
+            return stage.sections.flatMap(section => {
+                return section.questions.map(question => question);
+            });
+        });
+        const entityQuestions = this.entity?.questions || [];
+        return [...stageQuestions, ...entityQuestions];
+    }
+
     public static create(data: QuestionnaireData): Questionnaire {
         //TO DO : Add validations if any
         return new Questionnaire({
@@ -257,21 +268,11 @@ export class Questionnaire {
         questionnaire: Questionnaire,
         updatedQuestion: Question,
         stageId?: string,
-        initialLoad = false
+        initialLoad = false,
+        alreadyUpdatedQuestions?: undefined | Question[]
     ): Questionnaire {
         //For the updated question, get all rules that are applicable
-        const allQsInQuestionnaireStages = questionnaire.stages.flatMap(
-            (stage: QuestionnaireStage) => {
-                return stage.sections.flatMap(section => {
-                    return section.questions.map(question => question);
-                });
-            }
-        );
-
-        const allQsInQuestionnaire = [
-            ...(questionnaire.entity?.questions || []),
-            ...allQsInQuestionnaireStages,
-        ];
+        const allQsInQuestionnaire = questionnaire.getAllQuestions();
 
         const allQsInQuestionnaireWithUpdatedQ = allQsInQuestionnaire.map(question =>
             question.id === updatedQuestion.id ? updatedQuestion : question
@@ -289,7 +290,19 @@ export class Questionnaire {
             question => question.id === updatedQuestion.id
         );
 
-        return Questionnaire.create({
+        // "assign" actions may cause cascading updates
+        const assignRuleTargets: Question[] =
+            QuestionnaireQuestion.filterQuestionsTargettedByAssign(
+                allQsInQuestionnaireWithUpdatedQ,
+                applicableRules
+            )
+                // we don't want to update questions already updated to prevent infinite recursion
+                .filter(
+                    question =>
+                        question && !alreadyUpdatedQuestions?.some(uq => uq.id === question.id)
+                );
+
+        const updatedQuestionnaire = Questionnaire.create({
             ...questionnaire.data,
             stages: questionnaire.stages.map(stage => {
                 if (stageId && stage.id !== stageId) return stage;
@@ -313,6 +326,29 @@ export class Questionnaire {
                       )
                     : questionnaire.entity,
         });
+
+        if (assignRuleTargets.length > 0) {
+            // We need to update the questionnaire again based on updates from "assign" actions
+            const updatedQuestionnaireWithAssigns = assignRuleTargets.reduce(
+                (accQuestionnaire, question) => {
+                    const updatedAssignQuestion = QuestionnaireQuestion.updateQuestion(
+                        question,
+                        applicableRules
+                    );
+                    return this.updateQuestionnaire(
+                        accQuestionnaire,
+                        updatedAssignQuestion,
+                        stageId,
+                        initialLoad,
+                        [...(alreadyUpdatedQuestions ?? []), updatedAssignQuestion]
+                    );
+                },
+                updatedQuestionnaire
+            );
+
+            return updatedQuestionnaireWithAssigns;
+        }
+        return updatedQuestionnaire;
     }
 
     static doesQuestionnaireHaveErrors(questionnaire: Questionnaire): boolean {

--- a/src/domain/entities/Questionnaire/QuestionnaireQuestion.ts
+++ b/src/domain/entities/Questionnaire/QuestionnaireQuestion.ts
@@ -291,7 +291,27 @@ export class QuestionnaireQuestion {
         return finalUpdatesWithSideEffects;
     }
 
-    private static updateQuestion<T extends Question>(question: T, rules: QuestionnaireRule[]): T {
+    public static filterQuestionsTargettedByAssign(
+        questions: Question[],
+        applicableRules: QuestionnaireRule[]
+    ): Question[] {
+        return applicableRules
+            .flatMap(rule =>
+                rule.parsedResult
+                    ? rule.actions.filter(action => action.programRuleActionType === "ASSIGN")
+                    : []
+            )
+            .map(action =>
+                questions.find(
+                    q =>
+                        q.id === action.dataElement?.id ||
+                        q.id === action.trackedEntityAttribute?.id
+                )
+            )
+            .filter(x => x !== undefined) as Question[];
+    }
+
+    public static updateQuestion<T extends Question>(question: T, rules: QuestionnaireRule[]): T {
         const updatedIsVisible = this.isQuestionVisible(question, rules);
         const updatedErrors = this.getQuestionWarningsAndErrors(question, rules);
         const updatedIsDisabled = this.isQuestionDisabled(question, rules);


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8697wbx9k #8697wbx9k

### :memo: Implementation

- When a program rule with an "assign" action is executed, the Questionnaire needs to be updated again in order to re-evaluate program rules and trigger any other actions depending on the updated value. So a recursive call was added  to `Questionnaire.updateQuestionnaire` when assign rules are executed.
- At first I tried to handle this scenario at the level of `QuestionnaireQuestion.updateQuestions` with its `recursivelyApplySideEffects`, but at that level it is not possible to run the assign action and then run a "hidesection" action. 
- In the testing scenario, the first update is the user triggered action (change date), then the assign action changes "age group", and then the second update triggers the "hidesection" for the following sections.
- Currently we don't have any test case that would run `recursivelyApplySideEffects`, but it would be interesting to test a case in which both the assign rule and the `recursivelyApplySideEffects` run. I think it should work fine.

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/c6e5cd6a-93c8-469e-bc4a-d919a81439d4

