### PR TITLE
fix: disabled state for questions targetted by assign actions

### DIFF
--- a/src/domain/entities/Questionnaire/QuestionnaireQuestion.ts
+++ b/src/domain/entities/Questionnaire/QuestionnaireQuestion.ts
@@ -27,6 +27,7 @@ export interface QuestionBase {
     sortOrder: number | undefined;
     errors: string[];
     stageId?: Id; //For repeatable stages processing.
+    computed?: boolean; // true if value is the result of "assign" actions program rules
 }
 
 export interface SpeciesQuestion extends SelectQuestion {
@@ -314,13 +315,13 @@ export class QuestionnaireQuestion {
     public static updateQuestion<T extends Question>(question: T, rules: QuestionnaireRule[]): T {
         const updatedIsVisible = this.isQuestionVisible(question, rules);
         const updatedErrors = this.getQuestionWarningsAndErrors(question, rules);
-        const updatedIsDisabled = this.isQuestionDisabled(question, rules);
+        const updatedIsComputed = this.isQuestionComputed(question, rules);
         const updatedValue = this.getQuestionAssignValue(question, rules);
         return {
             ...question,
             isVisible: updatedIsVisible,
             errors: updatedErrors,
-            disabled: updatedIsDisabled,
+            computed: updatedIsComputed,
             value: updatedValue,
             ...(question.isVisible !== updatedIsVisible ? { value: undefined } : {}),
         };
@@ -343,12 +344,12 @@ export class QuestionnaireQuestion {
         );
     }
 
-    private static isQuestionDisabled(
+    private static isQuestionComputed(
         question: Question,
         rules: QuestionnaireRule[]
     ): boolean | undefined {
         const applicableRules = this.getRulesWithAssignActionForQuestion(question, rules);
-        return applicableRules.length > 0 ? true : question.disabled;
+        return applicableRules.length > 0;
     }
 
     private static getQuestionAssignValue(

--- a/src/webapp/components/survey/SurveySection.tsx
+++ b/src/webapp/components/survey/SurveySection.tsx
@@ -65,9 +65,11 @@ export const SurveySection: React.FC<SurveySectionProps> = ({
                                             <QuestionWidget
                                                 onChange={updateQuestion}
                                                 question={question}
-                                                disabled={
-                                                    question.disabled || viewOnly ? true : false
-                                                }
+                                                disabled={Boolean(
+                                                    question.disabled ||
+                                                        question.computed ||
+                                                        viewOnly
+                                                )}
                                                 treatmentOptions={treatmentOptions}
                                                 indicationOptions={indicationOptions}
                                             />

--- a/src/webapp/components/survey/TableSection.tsx
+++ b/src/webapp/components/survey/TableSection.tsx
@@ -61,11 +61,11 @@ export const TableSection: React.FC<TableSectionProps> = ({
                                                     <QuestionWidget
                                                         onChange={updateQuestion}
                                                         question={question}
-                                                        disabled={
-                                                            question.disabled || viewOnly
-                                                                ? true
-                                                                : false
-                                                        }
+                                                        disabled={Boolean(
+                                                            question.disabled ||
+                                                                question.computed ||
+                                                                viewOnly
+                                                        )}
                                                     />
                                                     {question.errors.map((err, index) => (
                                                         <div key={index}>


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8697y23cu #8697y23cu

### :memo: Implementation

- Added a new `computed` property  to `QuestionnaireQuestion`
  - This property is set to `true` when an "assign" action from a program rule sets the question value, otherwise `false`.
- Disable the `QuestionWidget` if `computed` value is true
- Why a new property?
  - Allows reverting the "disabled" state in the view
  - Prevents unintentionally enabling a field that was disabled due to other conditions 

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/27240154-091c-49e9-9ccd-85797b89cb96
