### PR TITLE
Disable save in forms that support Org Unit selection

### DIFF
--- a/src/domain/entities/Survey.ts
+++ b/src/domain/entities/Survey.ts
@@ -32,6 +32,13 @@ export const SURVEYS_WITH_CHILD_COUNT: SURVEY_FORM_TYPES[] = [
     "PPSWardRegister",
 ];
 
+export const SURVEYS_WITH_ORG_UNIT_SELECTOR: readonly SURVEY_FORM_TYPES[] = [
+    "PPSCountryQuestionnaire",
+    "PPSHospitalForm",
+    "PrevalenceSurveyForm",
+    "PrevalenceFacilityLevelForm",
+];
+
 export interface SurveyBase extends NamedRef {
     surveyType: string;
     astGuideline?: ASTGUIDELINE_TYPES;

--- a/src/webapp/components/survey/SurveyFormOUSelector.tsx
+++ b/src/webapp/components/survey/SurveyFormOUSelector.tsx
@@ -2,7 +2,7 @@ import { OrgUnitsSelector } from "@eyeseetea/d2-ui-components";
 import { useEffect } from "react";
 import { COUNTRY_OU_LEVEL, HOSPITAL_OU_LEVELS } from "../../../data/repositories/UserD2Repository";
 import { Id } from "../../../domain/entities/Ref";
-import { SURVEY_FORM_TYPES } from "../../../domain/entities/Survey";
+import { SURVEYS_WITH_ORG_UNIT_SELECTOR, SURVEY_FORM_TYPES } from "../../../domain/entities/Survey";
 import { OrgUnitAccess } from "../../../domain/entities/User";
 import { GLOBAL_OU_ID } from "../../../domain/usecases/SaveFormDataUseCase";
 import { getParentOUIdFromPath } from "../../../domain/utils/PPSProgramsHelper";
@@ -42,10 +42,7 @@ export const SurveyFormOUSelector: React.FC<SurveyFormOUSelectorProps> = ({
 
     return (
         <>
-            {(formType === "PPSCountryQuestionnaire" ||
-                formType === "PPSHospitalForm" ||
-                formType === "PrevalenceSurveyForm" ||
-                formType === "PrevalenceFacilityLevelForm") && (
+            {SURVEYS_WITH_ORG_UNIT_SELECTOR.includes(formType) && (
                 <OrgUnitsSelector
                     api={api}
                     fullWidth={false}

--- a/src/webapp/components/survey/hook/useSurveyForm.ts
+++ b/src/webapp/components/survey/hook/useSurveyForm.ts
@@ -31,7 +31,6 @@ export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | und
     const [questionnaire, setQuestionnaire] = useState<Questionnaire>();
     const [loading, setLoading] = useState<boolean>(false);
     const [currentOrgUnit, setCurrentOrgUnit] = useState<OrgUnitAccess>();
-    const [shouldDisableSave, setShouldDisableSave] = useState<boolean>(false);
     const [refreshQuestionnaire, setRefreshQuestionnaire] = useState({});
     const {
         currentPPSSurveyForm,
@@ -46,13 +45,15 @@ export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | und
     const [error, setError] = useState<string>();
     const { currentModule } = useCurrentModule();
 
-    useEffect(() => {
-        if (!questionnaire) setShouldDisableSave(true);
-        else {
-            const shouldDisable = Questionnaire.doesQuestionnaireHaveErrors(questionnaire);
-            setShouldDisableSave(shouldDisable || hasReadOnlyAccess);
+    const shouldDisableSave = useMemo(() => {
+        if (!questionnaire) return true;
+        const isDisabled =
+            Questionnaire.doesQuestionnaireHaveErrors(questionnaire) || hasReadOnlyAccess;
+        if (formType === "PrevalenceFacilityLevelForm") {
+            return isDisabled || !currentOrgUnit;
         }
-    }, [hasReadOnlyAccess, questionnaire]);
+        return isDisabled;
+    }, [hasReadOnlyAccess, questionnaire, currentOrgUnit, formType]);
 
     useEffect(() => {
         setLoading(true);

--- a/src/webapp/components/survey/hook/useSurveyForm.ts
+++ b/src/webapp/components/survey/hook/useSurveyForm.ts
@@ -4,7 +4,10 @@ import {
     Questionnaire,
     QuestionnaireStage,
 } from "../../../../domain/entities/Questionnaire/Questionnaire";
-import { SURVEY_FORM_TYPES } from "../../../../domain/entities/Survey";
+import {
+    SURVEYS_WITH_ORG_UNIT_SELECTOR,
+    SURVEY_FORM_TYPES,
+} from "../../../../domain/entities/Survey";
 import { OrgUnitAccess } from "../../../../domain/entities/User";
 import { useCurrentSurveys } from "../../../contexts/current-surveys-context";
 
@@ -49,7 +52,7 @@ export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | und
         if (!questionnaire) return true;
         const isDisabled =
             Questionnaire.doesQuestionnaireHaveErrors(questionnaire) || hasReadOnlyAccess;
-        if (formType === "PrevalenceFacilityLevelForm") {
+        if (SURVEYS_WITH_ORG_UNIT_SELECTOR.includes(formType)) {
             return isDisabled || !currentOrgUnit;
         }
         return isDisabled;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8697wb707 #8697wb707

### :memo: Implementation

- Changed `shouldDisableSave` from state to a memoized value since it's computed
- Added condition to return true if no OrgUnit is selected for `formType === "PrevalenceFacilityLevelForm"`

**UPDATE:**   applied the disable condition to all forms that support org unit selection. For that, extracted to a var `SURVEYS_WITH_ORG_UNIT_SELECTOR`.

### :video_camera: Screenshots/Screen capture


https://github.com/user-attachments/assets/5324317f-6f74-40aa-913e-faad93707fba

