### PR TITLE
fix: get hospitals for PPS HOSP surveys

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-02-13T17:58:53.810Z\n"
-"PO-Revision-Date: 2025-02-13T17:58:53.810Z\n"
+"POT-Creation-Date: 2025-02-25T14:41:42.341Z\n"
+"PO-Revision-Date: 2025-02-25T14:41:42.341Z\n"
 
 msgid "There was a problem with \"{{name}}\" - {{prop}} is not set"
 msgstr ""
@@ -291,4 +291,7 @@ msgid "Database language updated successfully"
 msgstr ""
 
 msgid "Error updating database language."
+msgstr ""
+
+msgid "Could not resolve Org Unit for current form"
 msgstr ""


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/86982m1wv #86982m1wv

### :memo: Implementation

- Default to `GLOBAL_OU_ID` when `surveyType === "HOSP"`
- Change `getOrgUnitByFormType` to allow returning `undefined`, and validate that there is an `orgUnitId` before making the `getSurveys` calls, since it's a required parameter.
  - An alternative was to always default to the `GLOBAL_OU_ID` when there is no `orgUnitId`, but that approach might mask other errors.

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/150c9e68-625b-49f2-a3f0-6d54eb71b1ee
