### PR TITLE
Feature/enable create facility button if has capture access

### DIFF
--- a/src/data/repositories/SurveyFormD2Repository.ts
+++ b/src/data/repositories/SurveyFormD2Repository.ts
@@ -399,14 +399,14 @@ export class SurveyD2Repository implements SurveyRepository {
                 programId === PPS_COUNTRY_QUESTIONNAIRE_ID ||
                 programId === PREVALENCE_SURVEY_FORM_ID)
                 ? "DESCENDANTS"
-                : "SELECTED";
+                : undefined;
 
         return apiToFuture(
             this.api.tracker.events.get({
                 fields: { $all: true },
                 program: programId,
-                orgUnit: orgUnitId,
-                ouMode: ouMode,
+                ...(orgUnitId !== "" && { orgUnit: orgUnitId }),
+                ...(ouMode && { ouMode: ouMode }),
                 filter: filter ? `${filter.id}:eq:${filter.value}` : undefined,
             })
         ).flatMap(response => {

--- a/src/domain/utils/PPSProgramsHelper.ts
+++ b/src/domain/utils/PPSProgramsHelper.ts
@@ -196,7 +196,8 @@ export const hideCreateNewButton = (
             currentPPSFormType === "NATIONAL" &&
             surveys !== undefined &&
             surveys.length >= 1) ||
-        (surveyFormType === "PrevalenceFacilityLevelForm" && !hasCaptureAccess)
+        (surveyFormType === "PrevalenceFacilityLevelForm" && !hasCaptureAccess) ||
+        (surveyFormType === "PrevalenceSurveyForm" && !isAdmin)
     );
 };
 

--- a/src/domain/utils/PPSProgramsHelper.ts
+++ b/src/domain/utils/PPSProgramsHelper.ts
@@ -183,19 +183,20 @@ export const getParentOUIdFromPath = (path: string | undefined) => {
 export const hideCreateNewButton = (
     surveyFormType: SURVEY_FORM_TYPES,
     isAdmin: boolean,
-    hasReadAccess: boolean,
+    hasOnlyReadAccess: boolean,
+    hasCaptureAccess: boolean,
     currentPPSFormType: string,
     surveys: Survey[] | undefined
 ): boolean => {
     return (
-        hasReadAccess ||
+        hasOnlyReadAccess ||
         (surveyFormType === "PPSHospitalForm" && !isAdmin) ||
         // For PPS Survey Forms of National Type, only one child survey(country) should be allowed.
         (surveyFormType === "PPSCountryQuestionnaire" &&
             currentPPSFormType === "NATIONAL" &&
             surveys !== undefined &&
             surveys.length >= 1) ||
-        (surveyFormType === "PrevalenceFacilityLevelForm" && !isAdmin)
+        (surveyFormType === "PrevalenceFacilityLevelForm" && !hasCaptureAccess)
     );
 };
 

--- a/src/domain/utils/menuHelper.ts
+++ b/src/domain/utils/menuHelper.ts
@@ -51,8 +51,7 @@ export const getBaseSurveyFormType = (
                 module,
                 currentUserGroups
             );
-            if (hasAdminAccess) return "PrevalenceSurveyForm";
-            else if (hasReadAccess || hasCaptureAccess) return "PrevalenceFacilityLevelForm";
+            if (hasAdminAccess || hasReadAccess || hasCaptureAccess) return "PrevalenceSurveyForm";
             else
                 throw new Error(
                     "You dont have the neccessary permissions. Please contact your system administrator."

--- a/src/domain/utils/menuHelper.ts
+++ b/src/domain/utils/menuHelper.ts
@@ -2,7 +2,16 @@ import { AMRSurveyModule } from "../entities/AMRSurveyModule";
 import { NamedRef } from "../entities/Ref";
 import { SURVEY_FORM_TYPES } from "../entities/Survey";
 
-export const getUserAccess = (module: AMRSurveyModule, currentUserGroups: NamedRef[]) => {
+export type UserAccess = {
+    hasReadAccess: boolean;
+    hasCaptureAccess: boolean;
+    hasAdminAccess: boolean;
+};
+
+export const getUserAccess = (
+    module: AMRSurveyModule,
+    currentUserGroups: NamedRef[]
+): UserAccess => {
     const hasReadAccess =
         currentUserGroups.filter(cug =>
             module.userGroups.readAccess?.some(raug => raug.id === cug.id)

--- a/src/webapp/components/survey-list/SurveyList.tsx
+++ b/src/webapp/components/survey-list/SurveyList.tsx
@@ -13,9 +13,6 @@ import {
     hideCreateNewButton,
     isPaginatedSurveyList,
 } from "../../../domain/utils/PPSProgramsHelper";
-import { getUserAccess } from "../../../domain/utils/menuHelper";
-import { useAppContext } from "../../contexts/app-context";
-import { useCurrentModule } from "../../contexts/current-module-context";
 import { SurveyListTable } from "./table/SurveyListTable";
 import { SurveyListFilters } from "./SurveyListFilters";
 import _ from "../../../domain/entities/generic/Collection";
@@ -23,19 +20,17 @@ import { useFilteredSurveys } from "./hook/useFilteredSurveys";
 import { PaginatedSurveyListTable } from "./table/PaginatedSurveyListTable";
 import { usePatientSearch } from "./hook/usePatientSearch";
 import useReadOnlyAccess from "../survey/hook/useReadOnlyAccess";
+import useCaptureAccess from "../survey/hook/useCaptureAccess";
+import useHasAdminAccess from "../survey/hook/useHasAdminAccess";
 
 interface SurveyListProps {
     surveyFormType: SURVEY_FORM_TYPES;
 }
 export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
     const { currentPPSSurveyForm } = useCurrentSurveys();
-    const { currentUser } = useAppContext();
-    const { currentModule } = useCurrentModule();
-    const { hasReadOnlyAccess } = useReadOnlyAccess();
-
-    const isAdmin = currentModule
-        ? getUserAccess(currentModule, currentUser.userGroups).hasAdminAccess
-        : false;
+    const { hasReadOnlyAccess: hasOnlyReadAccess } = useReadOnlyAccess();
+    const { hasCaptureAccess } = useCaptureAccess();
+    const { hasAdminAccess } = useHasAdminAccess();
 
     const {
         surveys,
@@ -55,7 +50,7 @@ export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
         surveyTypeFilter,
         setSurveyTypeFilter,
         filteredSurveys,
-    } = useFilteredSurveys(surveyFormType, isAdmin, surveys);
+    } = useFilteredSurveys(surveyFormType, hasAdminAccess, surveys);
 
     const {
         searchResultSurveys,
@@ -76,8 +71,9 @@ export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
                     <>
                         {!hideCreateNewButton(
                             surveyFormType,
-                            isAdmin,
-                            hasReadOnlyAccess,
+                            hasAdminAccess,
+                            hasOnlyReadAccess,
+                            hasCaptureAccess,
                             currentPPSSurveyForm?.surveyType
                                 ? currentPPSSurveyForm?.surveyType
                                 : "",

--- a/src/webapp/components/survey/hook/useCaptureAccess.ts
+++ b/src/webapp/components/survey/hook/useCaptureAccess.ts
@@ -1,25 +1,9 @@
-import { useState, useEffect } from "react";
-import { useAppContext } from "../../../contexts/app-context";
-import { useCurrentModule } from "../../../contexts/current-module-context";
-import { getUserAccess } from "../../../../domain/utils/menuHelper";
+import useUserAccess from "./useUserAccess";
 
 const useCaptureAccess = () => {
-    const { currentUser } = useAppContext();
-    const { currentModule } = useCurrentModule();
-    const [hasCaptureAccess, setHasCaptureAccess] = useState<boolean>(false);
+    const userAccess = useUserAccess();
 
-    useEffect(() => {
-        if (currentModule) {
-            const { hasCaptureAccess, hasAdminAccess } = getUserAccess(
-                currentModule,
-                currentUser.userGroups
-            );
-
-            setHasCaptureAccess(hasCaptureAccess || hasAdminAccess);
-        }
-    }, [currentModule, currentUser]);
-
-    return { hasCaptureAccess };
+    return { hasCaptureAccess: userAccess.hasCaptureAccess || userAccess.hasAdminAccess };
 };
 
 export default useCaptureAccess;

--- a/src/webapp/components/survey/hook/useHasAdminAccess.ts
+++ b/src/webapp/components/survey/hook/useHasAdminAccess.ts
@@ -1,22 +1,9 @@
-import { useState, useEffect } from "react";
-import { useAppContext } from "../../../contexts/app-context";
-import { useCurrentModule } from "../../../contexts/current-module-context";
-import { getUserAccess } from "../../../../domain/utils/menuHelper";
+import useUserAccess from "./useUserAccess";
 
 const useHasAdminAccess = () => {
-    const { currentUser } = useAppContext();
-    const { currentModule } = useCurrentModule();
-    const [hasAdminAccess, setHasAdminAccess] = useState<boolean>(false);
+    const userAccess = useUserAccess();
 
-    useEffect(() => {
-        if (currentModule) {
-            const { hasAdminAccess } = getUserAccess(currentModule, currentUser.userGroups);
-
-            setHasAdminAccess(hasAdminAccess);
-        }
-    }, [currentModule, currentUser]);
-
-    return { hasAdminAccess };
+    return { hasAdminAccess: userAccess.hasAdminAccess };
 };
 
 export default useHasAdminAccess;

--- a/src/webapp/components/survey/hook/useHasAdminAccess.ts
+++ b/src/webapp/components/survey/hook/useHasAdminAccess.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from "react";
+import { useAppContext } from "../../../contexts/app-context";
+import { useCurrentModule } from "../../../contexts/current-module-context";
+import { getUserAccess } from "../../../../domain/utils/menuHelper";
+
+const useHasAdminAccess = () => {
+    const { currentUser } = useAppContext();
+    const { currentModule } = useCurrentModule();
+    const [hasAdminAccess, setHasAdminAccess] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (currentModule) {
+            const { hasAdminAccess } = getUserAccess(currentModule, currentUser.userGroups);
+
+            setHasAdminAccess(hasAdminAccess);
+        }
+    }, [currentModule, currentUser]);
+
+    return { hasAdminAccess };
+};
+
+export default useHasAdminAccess;

--- a/src/webapp/components/survey/hook/useReadOnlyAccess.ts
+++ b/src/webapp/components/survey/hook/useReadOnlyAccess.ts
@@ -1,22 +1,16 @@
 import { useState, useEffect } from "react";
-import { useAppContext } from "../../../contexts/app-context";
-import { useCurrentModule } from "../../../contexts/current-module-context";
-import { getUserAccess } from "../../../../domain/utils/menuHelper";
+import useUserAccess from "./useUserAccess";
 
 const useReadOnlyAccess = () => {
-    const { currentUser } = useAppContext();
-    const { currentModule } = useCurrentModule();
     const [hasReadOnlyAccess, setHasReadOnlyAccess] = useState<boolean>(false);
 
+    const userAccess = useUserAccess();
+
     useEffect(() => {
-        if (currentModule) {
-            const { hasReadAccess, hasCaptureAccess, hasAdminAccess } = getUserAccess(
-                currentModule,
-                currentUser.userGroups
-            );
-            setHasReadOnlyAccess(hasReadAccess && !hasCaptureAccess && !hasAdminAccess);
-        }
-    }, [currentModule, currentUser.userGroups]);
+        setHasReadOnlyAccess(
+            userAccess.hasReadAccess && !userAccess.hasCaptureAccess && !userAccess.hasAdminAccess
+        );
+    }, [userAccess]);
 
     return { hasReadOnlyAccess };
 };

--- a/src/webapp/components/survey/hook/useUserAccess.ts
+++ b/src/webapp/components/survey/hook/useUserAccess.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react";
+import { useAppContext } from "../../../contexts/app-context";
+import { useCurrentModule } from "../../../contexts/current-module-context";
+import { getUserAccess, UserAccess } from "../../../../domain/utils/menuHelper";
+
+const useUserAccess = () => {
+    const { currentUser } = useAppContext();
+    const { currentModule } = useCurrentModule();
+    const [userAccess, setUserAccess] = useState<UserAccess>({
+        hasAdminAccess: false,
+        hasCaptureAccess: false,
+        hasReadAccess: false,
+    });
+
+    useEffect(() => {
+        if (currentModule) {
+            const userAccess = getUserAccess(currentModule, currentUser.userGroups);
+
+            setUserAccess(userAccess);
+        }
+    }, [currentModule, currentUser]);
+
+    return userAccess;
+};
+
+export default useUserAccess;

--- a/src/webapp/hooks/useSurveys.ts
+++ b/src/webapp/hooks/useSurveys.ts
@@ -63,6 +63,8 @@ export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
             case "PrevalenceCohortEnrolment":
             case "PrevalenceDischarge":
                 return currentFacilityLevelForm?.orgUnitId;
+            case "PrevalenceSurveyForm":
+                return undefined;
             default:
                 return GLOBAL_OU_ID;
         }
@@ -99,7 +101,7 @@ export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
 
         const orgUnitId = getOrgUnitByFormType();
 
-        if (!orgUnitId) {
+        if (!orgUnitId && surveyFormType !== "PrevalenceSurveyForm") {
             setSurveysError(i18n.t("Could not resolve Org Unit for current form"));
             return;
         }
@@ -111,7 +113,7 @@ export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
             compositionRoot.surveys.getPaginatedSurveys
                 .execute(
                     surveyFormType,
-                    orgUnitId,
+                    orgUnitId || "",
                     parentSurveyId,
                     currentWardRegister?.id,
                     currentCaseReportForm?.id,
@@ -136,7 +138,7 @@ export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
                 surveyFormType === "PrevalenceFacilityLevelForm" && !isAdmin;
             //Other forms are not paginated.
             compositionRoot.surveys.getSurveys
-                .execute(surveyFormType, orgUnitId, parentSurveyId, makeChunkedCall)
+                .execute(surveyFormType, orgUnitId || "", parentSurveyId, makeChunkedCall)
                 .run(
                     nonPaginatedSurveys => {
                         setSurveys(nonPaginatedSurveys);

--- a/src/webapp/pages/survey-list/SurveyListPage.tsx
+++ b/src/webapp/pages/survey-list/SurveyListPage.tsx
@@ -33,7 +33,6 @@ export const SurveyListPage: React.FC = React.memo(() => {
                 (formType === "PrevalenceFacilityLevelForm" || formType === "PPSHospitalForm"))
         ) {
             resetCurrentPPSSurveyForm();
-            resetCurrentPrevalenceSurveyForm();
         } else if (shouldRedirectToHome(formType)) {
             //Redirecting to home page.
             history.push("/");


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8699cr80d #8699cr80d

### :memo: Implementation

- [x] Enable create facility button for non admin user with capture access
- [x] refactor. Simplify custom hooks avoiding duplicate code
- [x] Avoid jump to facilities for prevalence and non admin user
- [x] Avoid global error to retrieve surveys for non admin users
- [x] Avoid reset current prevalence survey to load facilities for non admin users

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
