### PR TITLE
Fix new facility menu

### DIFF
--- a/src/webapp/components/survey-list/table/SurveyListTable.tsx
+++ b/src/webapp/components/survey-list/table/SurveyListTable.tsx
@@ -334,7 +334,7 @@ export const SurveyListTable: React.FC<SurveyListTableProps> = ({
                                                                 option:
                                                                     options.find(option =>
                                                                         option.label.startsWith(
-                                                                            "Add"
+                                                                            "New"
                                                                         )
                                                                     )?.label || "",
                                                                 handler: () => assignChild(survey),


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8699wt59t #8699wt59t

### :memo: Implementation

- [x] Fix new facility menu

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/84fea43e-0a33-4e82-b603-d4bd6c93d70f

### :fire: Notes to the tester

The origin of the problem was the change of menu labels from add to new.

The error occurred only for records in PaginaedSurveyListTable but not for records in PaginaedSurveyListTable
