### PR TITLE
Send attributes only under tracked entity

### DIFF
--- a/src/data/utils/surveyFormMappers.ts
+++ b/src/data/utils/surveyFormMappers.ts
@@ -441,7 +441,7 @@ export const mapQuestionnaireToTrackedEntities = (
             enrollment: questionnaire.subLevelDetails?.enrollmentId ?? "",
             trackedEntityType: getTrackedEntityAttributeType(programId, modules),
             notes: [],
-            attributes: attributes,
+            attributes: [],
             events: eventsByStage as D2TrackerEvent[],
             enrolledAt: new Date().getTime().toString(),
             occurredAt: new Date().getTime().toString(),


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869a9cze4 #869a9cze4

### :memo: Implementation

- [x] Avoid send attributes twice under tracked entity and enrollment because this provokes a bug in dhis2 if there is a attribute to delete

### :video_camera: Screenshots/Screen capture

Before

https://github.com/user-attachments/assets/330f8a05-8e4c-405c-a9f6-62daf1508c03

After

https://github.com/user-attachments/assets/6736d210-2e02-471f-ad68-28cbb8315ec9

### :fire: Notes to the tester

I’ve found the cause of the bug. It’s not a problem with the case report form; it’s a problem with all forms provoked by the app and a bug in dhis2.

I've debugged the core using d2-docker and the current eyeseetea fork branch.

After debug the core I’ve identified the problem.

The problem occurs when we send the payload so:


```json
{
    "trackedEntities": [
        {
            "enrollments": [
                {
                    "attributes": [...],
                    "events": [...]
                }
            ],
            "attributes": [...],
            "relationships": [...]
        }
    ]
}
```

The bug is provoked when we send attribute values under enrollment and tracked entity.

And there is an attribute value that exists with value in the server, and the current modification requires that the existing attribute value be deleted in the server

When this scenario occurs and this attribute exists in the payload two places

trackedEntity.attributes and trackedEntity.enrollments[0].attributes 

This provokes that the class AbstractTrackerPersister of the core (line 342) tries to delete
 the same attribute value twice in the same transaction

https://github.com/EyeSeeTea/dhis2-core/blob/5d8263cb646f114e0cecbcbbbaeeb283632c9386/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java#L342

```
Hibernate throws the error: 
org.hibernate.ObjectDeletedException: deleted instance passed to merge: [org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue#<null>]
```

Basically is when an object is marked to be deleted in the same transaction twice.

This throws a PersistenceException bad controlled where the result is persistenceReport
 Is null here:

https://github.com/EyeSeeTea/dhis2-core/blob/5d8263cb646f114e0cecbcbbbaeeb283632c9386/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java#L124

When DefaultTrackerImportService tries to create the report using persistenceReport that it’s null provokes the final error 500:

```json
{
    "httpStatus": "Internal Server Error",
    "httpStatusCode": 500,
    "status": "ERROR",
    "message": "Cannot invoke \"org.hisp.dhis.tracker.imports.report.PersistenceReport.getStats()\" because \"persistenceReport\" is null"
}
```

Why does the old tracker app and capture not fail?

Because never send the payload as us.

To edit profile only send attributes 
To edit enrollments or events, only send it attributes under the enrollment object

The solutions are:

1 - Split the post into two requests:
First with attributes
Second, with enrollments and events

2 - Send all in one request, but without attributes under enrollments, only under the tracked entity.

This is the option recommended by Dhis2 AI:

Send attributes only in the TrackedEntity object (trackedEntities[].attributes), not in enrollment.attributes. Internally, attributes belong to the Tracked Entity, and there’s an ongoing task to remove attributes from Enrollment to avoid confusion/errors ([Tracked entity attributes under TrackedEntity, not Enrollment](https://dhis2.atlassian.net/browse/DHIS2-16093)).

