### PR TITLE
Fix bug request form in 2.41.5 version

### DIFF
--- a/src/data/entities/D2Program.ts
+++ b/src/data/entities/D2Program.ts
@@ -17,6 +17,7 @@ export interface Program {
     code: string;
     id: string;
     name: string;
+    programTrackedEntityAttributes: ProgramTrackedEntityAttibute[];
 }
 
 export interface ProgramStageDataElement {
@@ -39,6 +40,7 @@ export interface ProgramStage {
     sortOrder: number;
     repeatable: boolean;
     ProgramStageSection: ProgramStageSection[];
+    programStageDataElements: ProgramStageDataElement[];
 }
 
 export interface ProgramDataElement {
@@ -82,13 +84,11 @@ export interface ProgramTrackedEntityAttibute {
 }
 export interface ProgramMetadata {
     programs: Program[];
-    programStageDataElements: ProgramStageDataElement[];
     programStageSections?: ProgramStageSection[];
     dataElements: ProgramDataElement[];
     optionSets: OptionSet[];
     options: Option[];
     trackedEntityAttributes?: TrackedEntityAttibute[];
-    programTrackedEntityAttributes: ProgramTrackedEntityAttibute[];
     programStages: ProgramStage[];
     programRules: D2ProgramRule[];
     programRuleVariables: D2ProgramRuleVariable[];

--- a/src/data/repositories/SurveyFormD2Repository.ts
+++ b/src/data/repositories/SurveyFormD2Repository.ts
@@ -85,9 +85,11 @@ export class SurveyD2Repository implements SurveyRepository {
             })
         ).flatMap(resp => {
             if (resp.programs[0]) {
-                const programDataElements = resp.programStageDataElements.map(
-                    psde => psde.dataElement
-                );
+                const programStageDataElements = resp.programStages
+                    .map(ps => ps.programStageDataElements)
+                    .flat();
+
+                const programDataElements = programStageDataElements.map(psde => psde.dataElement);
 
                 const dataElementsWithSortOrder: ProgramDataElement[] = resp.programStageSections
                     ? resp.programStageSections.flatMap(section => {
@@ -113,15 +115,19 @@ export class SurveyD2Repository implements SurveyRepository {
                     : resp.dataElements.map(de => {
                           return {
                               ...de,
-                              sortOrder: resp.programStageDataElements.find(
+                              sortOrder: programStageDataElements.find(
                                   psde => psde.dataElement.id === de.id
                               )?.sortOrder,
                           };
                       });
 
-                const sortedTrackedentityAttr = resp.programTrackedEntityAttributes
+                const programTrackedEntityAttributes = resp.programs
+                    .map(program => program.programTrackedEntityAttributes)
+                    .flat();
+
+                const sortedTrackedentityAttr = programTrackedEntityAttributes
                     ? _(
-                          _(resp.programTrackedEntityAttributes)
+                          _(programTrackedEntityAttributes)
                               .sortBy(te => te.sortOrder)
                               .value()
                               .map(pste =>


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869ab1njz #869ab1njz
### :memo: Implementation

- [x] Change model types according to 2.41.5 response
- [x] Extract programStagesDataElements from programStages
- [x] Extract programTrackedEntityAttributes from programs

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester

Before, the programStageDataElements was a key in the root of the response:

```json
{
   "ProgramStageDataElements":[],
   "ProgramStages":[]
}
```

Now, this key is only under the program Stages. Then It's been necessary:
1 -Change de model types of the response 
2 -Extract programStageDataElements from programStages

```json
{
   "ProgramStages":[
      {
         "programStageDataElements":[]
      },
      {
         "programStageDataElements":[]
      },
   ]
}
```

When I tested, I saw something weird in the form. The order was not how I remembered. 

Analysing the response, I saw that another key is missing now, programTrackedEntityAttributes:

Before, the programTrackedEntityAttributes was also a key in the root of the response:
 
```json
{
   "programTrackedEntityAttributes":[],
   "programs":[]
}
```
 
Now, this key is only under the program. Then It's been necessary:
1 -Change de model types about program of the response 
2 -Extract programTrackedEntityAttributes from programs

```json 
{
   "programs":[
      {
        "programTrackedEntityAttributes":[]
      },
      {
        "programTrackedEntityAttributes":[]
      },
   ]
}
```

With these two changes, now the form is rendered equal that in the previous server version.
