### PR TITLE
Fix design breakpoints and tables in tablet devices

### DIFF
--- a/src/webapp/components/main-layout/MainLayout.tsx
+++ b/src/webapp/components/main-layout/MainLayout.tsx
@@ -26,13 +26,22 @@ export const MainLayout: React.FC<PropsWithChildren> = ({ children }) => {
             </div>
             <LandingContainer>
                 <Grid container spacing={6}>
-                    <Grid item xs={12} sm={2} style={{ display: showMenu ? "block" : "none" }}>
+                    <Grid
+                        item
+                        xs={12}
+                        sm={4}
+                        md={3}
+                        lg={2}
+                        style={{ display: showMenu ? "block" : "none" }}
+                    >
                         <LeftNav />
                     </Grid>
                     <Grid
                         item
                         xs={12}
-                        sm={10}
+                        sm={8}
+                        md={9}
+                        lg={10}
                         style={{
                             overflow: "auto",
                         }}

--- a/src/webapp/components/survey-list/SurveyList.tsx
+++ b/src/webapp/components/survey-list/SurveyList.tsx
@@ -1,5 +1,5 @@
 import i18n from "@eyeseetea/feedback-component/locales";
-import { Backdrop, Button, CircularProgress, TextField, Typography } from "@material-ui/core";
+import { Backdrop, Button, CircularProgress, Grid, TextField, Typography } from "@material-ui/core";
 import { NavLink } from "react-router-dom";
 import styled from "styled-components";
 import { useSurveys } from "../../hooks/useSurveys";
@@ -79,54 +79,72 @@ export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
                                 : "",
                             surveys
                         ) && (
-                            <ButtonWrapper>
-                                {surveyFormType === "PPSPatientRegister" && (
-                                    <>
-                                        <TextField
-                                            label={i18n.t("Search Patient ID")}
-                                            helperText={i18n.t("Filter by patient id")}
-                                            value={patientIdSearchKeyword}
-                                            onChange={e =>
-                                                setPatientIdSearchKeyword(e.target.value)
-                                            }
-                                            onKeyDown={handlePatientIdSearch}
-                                        />
-                                        <TextField
-                                            label={i18n.t("Search Patient Code")}
-                                            helperText={i18n.t("Filter by patientcode")}
-                                            value={patientCodeSearchKeyword}
-                                            onChange={e =>
-                                                setPatientCodeSearchKeyword(e.target.value)
-                                            }
-                                            onKeyDown={handlePatientCodeSearch}
-                                        />
-                                    </>
+                            <StyledGrid container>
+                                {(surveyFormType === "PPSPatientRegister" ||
+                                    surveyFormType === "PrevalenceCaseReportForm") && (
+                                    <StyledGridItem item xs={12} md={5}>
+                                        {surveyFormType === "PPSPatientRegister" && (
+                                            <>
+                                                <TextField
+                                                    label={i18n.t("Search Patient ID")}
+                                                    helperText={i18n.t("Filter by patient id")}
+                                                    value={patientIdSearchKeyword}
+                                                    onChange={e =>
+                                                        setPatientIdSearchKeyword(e.target.value)
+                                                    }
+                                                    onKeyDown={handlePatientIdSearch}
+                                                />
+                                                <TextField
+                                                    label={i18n.t("Search Patient Code")}
+                                                    helperText={i18n.t("Filter by patientcode")}
+                                                    value={patientCodeSearchKeyword}
+                                                    onChange={e =>
+                                                        setPatientCodeSearchKeyword(e.target.value)
+                                                    }
+                                                    onKeyDown={handlePatientCodeSearch}
+                                                />
+                                            </>
+                                        )}
+                                        {surveyFormType === "PrevalenceCaseReportForm" && (
+                                            <>
+                                                <TextField
+                                                    label={i18n.t("Search Patient ID")}
+                                                    helperText={i18n.t("Filter by patient id")}
+                                                    value={patientIdSearchKeyword}
+                                                    onChange={e =>
+                                                        setPatientIdSearchKeyword(e.target.value)
+                                                    }
+                                                    onKeyDown={handlePatientIdSearch}
+                                                />
+                                            </>
+                                        )}
+                                    </StyledGridItem>
                                 )}
-                                {surveyFormType === "PrevalenceCaseReportForm" && (
-                                    <>
-                                        <TextField
-                                            label={i18n.t("Search Patient ID")}
-                                            helperText={i18n.t("Filter by patient id")}
-                                            value={patientIdSearchKeyword}
-                                            onChange={e =>
-                                                setPatientIdSearchKeyword(e.target.value)
-                                            }
-                                            onKeyDown={handlePatientIdSearch}
-                                        />
-                                    </>
-                                )}
-                                <Button
-                                    variant="contained"
-                                    color="primary"
-                                    component={NavLink}
-                                    to={{
-                                        pathname: `/new-survey/${surveyFormType}`,
-                                    }}
-                                    exact={true}
+                                <StyledGridItem
+                                    item
+                                    xs={12}
+                                    md={
+                                        surveyFormType === "PPSPatientRegister" ||
+                                        surveyFormType === "PrevalenceCaseReportForm"
+                                            ? 5
+                                            : 12
+                                    }
                                 >
-                                    {i18n.t(`Create New ${getSurveyDisplayName(surveyFormType)}`)}
-                                </Button>
-                            </ButtonWrapper>
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        component={NavLink}
+                                        to={{
+                                            pathname: `/new-survey/${surveyFormType}`,
+                                        }}
+                                        exact={true}
+                                    >
+                                        {i18n.t(
+                                            `Create New ${getSurveyDisplayName(surveyFormType)}`
+                                        )}
+                                    </Button>
+                                </StyledGridItem>
+                            </StyledGrid>
                         )}
                     </>
 
@@ -185,10 +203,22 @@ const ContentWrapper = styled.div`
     }
 `;
 
-const ButtonWrapper = styled.div`
-    margin: 20px;
+const StyledGrid = styled(Grid)`
+    margin: 0px;
+
+    @media (max-width: 599px) {
+        padding: 10px !important;
+    }
+`;
+
+const StyledGridItem = styled(Grid)`
+    margin: 20px !important;
     display: flex;
     flex-direction: row;
     align-items: center;
     justify-content: space-around;
+
+    @media (max-width: 599px) {
+        margin: 10px !important;
+    }
 `;

--- a/src/webapp/components/survey-list/table/PaginatedSurveyListTable.tsx
+++ b/src/webapp/components/survey-list/table/PaginatedSurveyListTable.tsx
@@ -379,6 +379,7 @@ const TableContentWrapper = styled.div`
             vertical-align: bottom;
             position: relative;
             padding-block-end: 30px;
+            min-width: 70px;
             &:not(:last-child):after {
                 content: "";
                 height: 25px;
@@ -424,5 +425,7 @@ const StyledTableBody = styled(TableBody)`
     }
 `;
 const StyledTable = styled(Table)`
-    table-layout: fixed;
+    @media (min-width: 1280px) {
+        table-layout: fixed;
+    }
 `;

--- a/src/webapp/components/survey-list/table/SurveyListTable.tsx
+++ b/src/webapp/components/survey-list/table/SurveyListTable.tsx
@@ -390,7 +390,7 @@ const TableContentWrapper = styled.div`
             vertical-align: bottom;
             position: relative;
             padding-block-end: 30px;
-            min-width: 60px;
+            min-width: 70px;
             &:not(:last-child):after {
                 content: "";
                 height: 25px;

--- a/src/webapp/components/survey-list/table/SurveyListTable.tsx
+++ b/src/webapp/components/survey-list/table/SurveyListTable.tsx
@@ -390,6 +390,7 @@ const TableContentWrapper = styled.div`
             vertical-align: bottom;
             position: relative;
             padding-block-end: 30px;
+            min-width: 60px;
             &:not(:last-child):after {
                 content: "";
                 height: 25px;

--- a/src/webapp/pages/landing/LandingPage.tsx
+++ b/src/webapp/pages/landing/LandingPage.tsx
@@ -5,11 +5,21 @@ import styled from "styled-components";
 export const LandingPage: React.FC = React.memo(() => {
     return (
         <Container>
-            <Typography variant="h6">Coming Soon! - AMR Surveys Landing Page</Typography>
+            <CenteredContent>
+                <Typography variant="h6">Coming Soon! - AMR Surveys Landing Page</Typography>
+            </CenteredContent>
         </Container>
     );
 });
 
 const Container = styled.div`
-    padding: 300px;
+    height: 90vh;
+`;
+
+const CenteredContent = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
 `;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869agtur3 #869agtur3

### :memo: Implementation

- [x] Improve the responsiveness in tablet devices
   - [x] Fix layout with left side and main side 
   - [x] For normal tables (survey, facility), assign a min-width and left show scroll when it's necessary
   - [x] For paginated tables (case report, ...) in desktop force table-layout: fixed to adjust columns to tablet width
   - [x] For paginated tables (case report, ...), assign a min-width and left show scroll when it's necessary

### :video_camera: Screenshots/Screen capture
<img width="768" height="578" alt="Ipad portrait - surveys" src="https://github.com/user-attachments/assets/3c42676e-23a4-4a9b-9a24-ed90e080e5a5" />

<img width="768" height="578" alt="iPad Landscape - surveys (1)" src="https://github.com/user-attachments/assets/965d5e50-885e-44a7-8c04-1dab9930320e" />


<img width="768" height="578" alt="iPad Pro portrait - surveys" src="https://github.com/user-attachments/assets/fc4e50ed-b3f4-4206-8106-fc0a208ad645" />

<img width="768" height="578" alt="Asus Zenbook Fold portrait - surveys" src="https://github.com/user-attachments/assets/d5a44882-88f2-48fa-924f-529b7434a705" />

<img width="768" height="578" alt="iPad portrait - Case reports" src="https://github.com/user-attachments/assets/fec5bd98-f238-4785-b8da-4e724d531c05" />
<img width="768" height="578" alt="iPad Pro portrait - Case reports" src="https://github.com/user-attachments/assets/55572d7b-e325-46f9-913d-bb9a638c2667" />

<img width="768" height="578" alt="Asus Zenbook Fod portrait - Case reports" src="https://github.com/user-attachments/assets/ea05b88d-7cfd-484d-93f7-8724f0a04887" />

No affected changes in forms
<img width="385" height="513" alt="Screenshot 2025-09-18 at 10 35 57" src="https://github.com/user-attachments/assets/8a8757ff-18aa-43d5-82d3-95cdcb9f2d0c" />


No affected changes in desktop

<img width="1920" height="896" alt="Screenshot 2025-09-18 at 10 37 09" src="https://github.com/user-attachments/assets/67792016-5cf8-4eb8-88c1-6eea012255ee" />



<img width="401" height="578" alt="Iphone 12 Pro portrait - Home" src="https://github.com/user-attachments/assets/92bf0933-44cf-45c0-9796-2583870fc2fc" />

<img width="401" height="578" alt="Iphone 12 Pro portrait - Surveys (1)" src="https://github.com/user-attachments/assets/efa20c47-a1a3-4235-a78d-4c93dbd8c52d" />

<img width="401" height="578" alt="Iphone 12 Pro portrait - Case reports (1)" src="https://github.com/user-attachments/assets/7646f9c3-2b16-46ce-92f6-8d8ae6e77bc7" />



### :fire: Notes to the tester

Two main issues were detected:

1 - Distribution of space between Menu and main content
2 - Table rendering on tablets

For the menu, I extended the definition of breakpoints to 4 levels to cover all scenarios: desktop, tablets of different sizes in both landscape and portrait.

For the tables, we need to distinguish between two types:

Normal (survey and facility)

Paginated (case reports, etc. with more columns)

For the normal ones, I set a minimum cell width so that headers don’t get compressed on tablets. A horizontal scroll appears when necessary.

For the paginated ones, there was a configuration that tried to fit all the columns into the table width using table-layout: fixed. This caused them to get compressed on tablet screens, making headers hard to read. Now, this configuration only applies to desktop.

For tablets, in paginated tables, I set a minimum cell width so that headers don’t get compressed. A horizontal scroll appears when necessary.

No changes in forms for tablets, since they already looked fine.
No changes in the entire app for desktop, since it already looked fine.


