### PR TITLE
Set full width in main component if menu is hidden

### DIFF
--- a/src/webapp/components/main-layout/MainLayout.tsx
+++ b/src/webapp/components/main-layout/MainLayout.tsx
@@ -39,9 +39,9 @@ export const MainLayout: React.FC<PropsWithChildren> = ({ children }) => {
                     <Grid
                         item
                         xs={12}
-                        sm={8}
-                        md={9}
-                        lg={10}
+                        sm={showMenu ? 8 : 12}
+                        md={showMenu ? 9 : 12}
+                        lg={showMenu ? 10 : 12}
                         style={{
                             overflow: "auto",
                         }}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869akhcgh #869akhcgh

### :memo: Implementation

- [x] Set full width in main component if menu is hidden

### :video_camera: Screenshots/Screen capture
<img width="385" height="511" alt="Screenshot 2025-09-30 at 10 50 47" src="https://github.com/user-attachments/assets/62f12666-7cf8-4913-8838-70f311e16952" />
<img width="384" height="512" alt="Screenshot 2025-09-30 at 10 50 56" src="https://github.com/user-attachments/assets/b1024103-b129-45df-8fc4-c8950928f84e" />

### :fire: Notes to the tester
