### PR TITLE
[fix]: Ward summary form bugs

### DIFF
--- a/src/data/repositories/UserD2Repository.ts
+++ b/src/data/repositories/UserD2Repository.ts
@@ -282,6 +282,7 @@ const userFields = {
     organisationUnits: {
         id: true,
         name: true,
+        level: true,
     },
     dataViewOrganisationUnits: {
         id: true,

--- a/src/data/repositories/WardFormD2Repository.ts
+++ b/src/data/repositories/WardFormD2Repository.ts
@@ -201,10 +201,12 @@ export class WardFormD2Repository implements WardFormRepository {
 
                                 const wardEventCoc = categoryOptionCombos.find(coc => {
                                     const cocNames = coc.categoryOptions.map(co => co.name);
-                                    return (
-                                        cocNames.includes(uniqueWardId) &&
-                                        cocNames.includes(specialtyCode)
+                                    const hasWardId = cocNames.some(cocName =>
+                                        uniqueWardId.endsWith(cocName)
                                     );
+                                    const hasSpecialtyCode = cocNames.includes(specialtyCode);
+
+                                    return hasWardId && hasSpecialtyCode;
                                 });
 
                                 if (!wardEventCoc) {

--- a/src/domain/entities/Survey.ts
+++ b/src/domain/entities/Survey.ts
@@ -43,6 +43,11 @@ export const SURVEYS_WITH_ORG_UNIT_SELECTOR: readonly SURVEY_FORM_TYPES[] = [
     "WardSummaryStatisticsForm",
 ];
 
+export const SURVEYS_WITH_COUNTRY_LEVEL_OU: SURVEY_FORM_TYPES[] = [
+    "PPSCountryQuestionnaire",
+    "PrevalenceSurveyForm",
+];
+
 export interface SurveyBase extends NamedRef {
     surveyType: string;
     astGuideline?: ASTGUIDELINE_TYPES;

--- a/src/domain/entities/User.ts
+++ b/src/domain/entities/User.ts
@@ -25,6 +25,10 @@ export interface UserSettings {
     keyMessageEmailNotification: boolean;
     keyMessageSmsNotification: boolean;
 }
+
+export type UserOrgUnit = NamedRef & {
+    level: number;
+};
 export interface UserAttrs {
     id: string;
     name: string;
@@ -44,7 +48,7 @@ export interface UserAttrs {
     interests: string;
     languages: string;
     settings: UserSettings;
-    organisationUnits: NamedRef[];
+    organisationUnits: UserOrgUnit[];
     dataViewOrganisationUnits: NamedRef[];
 }
 

--- a/src/webapp/components/survey/SurveyFormOUSelector.tsx
+++ b/src/webapp/components/survey/SurveyFormOUSelector.tsx
@@ -1,15 +1,16 @@
 import { OrgUnitsSelector } from "@eyeseetea/d2-ui-components";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { COUNTRY_OU_LEVEL, HOSPITAL_OU_LEVELS } from "../../../data/repositories/UserD2Repository";
 import { Id } from "../../../domain/entities/Ref";
 import { SURVEYS_WITH_ORG_UNIT_SELECTOR, SURVEY_FORM_TYPES } from "../../../domain/entities/Survey";
-import { OrgUnitAccess } from "../../../domain/entities/User";
+import { OrgUnitAccess, UserOrgUnit } from "../../../domain/entities/User";
 import { GLOBAL_OU_ID } from "../../../domain/usecases/SaveFormDataUseCase";
 import { getParentOUIdFromPath } from "../../../domain/utils/PPSProgramsHelper";
 import { useAppContext } from "../../contexts/app-context";
 import { useCurrentSurveys } from "../../contexts/current-surveys-context";
 import { useSurveyFormOUSelector } from "./hook/useSurveyFormOUSelector";
 import { useOfflineSnackbar } from "../../hooks/useOfflineSnackbar";
+import _c from "../../../domain/entities/generic/Collection";
 
 export interface SurveyFormOUSelectorProps {
     formType: SURVEY_FORM_TYPES;
@@ -24,7 +25,7 @@ export const SurveyFormOUSelector: React.FC<SurveyFormOUSelectorProps> = ({
     setCurrentOrgUnit,
     currentSurveyId,
 }) => {
-    const { api } = useAppContext();
+    const { api, currentUser } = useAppContext();
     const { currentPPSSurveyForm, currentCountryQuestionnaire, currentPrevalenceSurveyForm } =
         useCurrentSurveys();
     const { onOrgUnitChange, ouSelectorErrMsg, shouldRefresh } = useSurveyFormOUSelector(
@@ -40,6 +41,47 @@ export const SurveyFormOUSelector: React.FC<SurveyFormOUSelectorProps> = ({
         }
     }, [ouSelectorErrMsg, snackbar, shouldRefresh, offlineError]);
 
+    const rootIds = useMemo(() => {
+        if (formType === "PPSHospitalForm") {
+            // For HOSP PPS surveys, show all hospitals across all OUs
+            if (currentPPSSurveyForm?.surveyType === "HOSP") {
+                return [GLOBAL_OU_ID];
+            }
+            // For non-admin user, currentCountryQuestionnaire won't be set. Get parent id from path
+            return currentCountryQuestionnaire?.orgUnitId
+                ? [currentCountryQuestionnaire.orgUnitId]
+                : [getParentOUIdFromPath(currentOrgUnit?.orgUnitPath)];
+        }
+
+        if (formType === "PrevalenceFacilityLevelForm") {
+            return [currentPrevalenceSurveyForm?.orgUnitId];
+        }
+
+        if (formType === "WardSummaryStatisticsForm") {
+            return getRootIds(currentUser.organisationUnits);
+        }
+
+        return [GLOBAL_OU_ID];
+    }, [
+        formType,
+        currentPPSSurveyForm?.surveyType,
+        currentCountryQuestionnaire?.orgUnitId,
+        currentOrgUnit?.orgUnitPath,
+        currentPrevalenceSurveyForm?.orgUnitId,
+        currentUser.organisationUnits,
+    ]);
+
+    const selectableLevels = useMemo(() => {
+        switch (formType) {
+            case "PPSCountryQuestionnaire":
+            case "PrevalenceSurveyForm":
+            case "WardSummaryStatisticsForm":
+                return HOSPITAL_OU_LEVELS;
+            default:
+                return [COUNTRY_OU_LEVEL];
+        }
+    }, [formType]);
+
     return (
         <>
             {SURVEYS_WITH_ORG_UNIT_SELECTOR.includes(formType) && (
@@ -54,29 +96,14 @@ export const SurveyFormOUSelector: React.FC<SurveyFormOUSelectorProps> = ({
                     singleSelection={true}
                     typeInput={"radio"}
                     hideMemberCount={false}
-                    selectableLevels={
-                        formType === "PPSCountryQuestionnaire" ||
-                        formType === "PrevalenceSurveyForm"
-                            ? [COUNTRY_OU_LEVEL]
-                            : HOSPITAL_OU_LEVELS
-                    }
+                    selectableLevels={selectableLevels}
                     controls={{
                         filterByLevel: false,
                         filterByGroup: false,
                         filterByProgram: false,
                         selectAll: false,
                     }}
-                    rootIds={
-                        formType === "PPSHospitalForm"
-                            ? currentPPSSurveyForm?.surveyType === "HOSP" //For HOSP PPS surveys, show all hospitals across all OUs
-                                ? [GLOBAL_OU_ID]
-                                : currentCountryQuestionnaire?.orgUnitId
-                                ? [currentCountryQuestionnaire?.orgUnitId] //For non-admin user, currentCountryQuestionnaire wont be set. Get parent id from path
-                                : [getParentOUIdFromPath(currentOrgUnit?.orgUnitPath)]
-                            : formType === "PrevalenceFacilityLevelForm"
-                            ? [currentPrevalenceSurveyForm?.orgUnitId]
-                            : [GLOBAL_OU_ID]
-                    }
+                    rootIds={rootIds}
                     showShortName={true}
                     showNameSetting={true}
                 />
@@ -84,3 +111,15 @@ export const SurveyFormOUSelector: React.FC<SurveyFormOUSelectorProps> = ({
         </>
     );
 };
+
+function getRoots(orgUnits: UserOrgUnit[]): UserOrgUnit[] {
+    const minLevel = Math.min(...orgUnits.map(ou => ou.level));
+    return _c(orgUnits)
+        .filter(ou => ou.level === minLevel)
+        .sortBy(ou => ou.name)
+        .value();
+}
+
+export function getRootIds(orgUnits: UserOrgUnit[]): Id[] {
+    return getRoots(orgUnits).map(ou => ou.id);
+}

--- a/src/webapp/components/survey/SurveyFormOUSelector.tsx
+++ b/src/webapp/components/survey/SurveyFormOUSelector.tsx
@@ -2,7 +2,11 @@ import { OrgUnitsSelector } from "@eyeseetea/d2-ui-components";
 import { useEffect, useMemo } from "react";
 import { COUNTRY_OU_LEVEL, HOSPITAL_OU_LEVELS } from "../../../data/repositories/UserD2Repository";
 import { Id } from "../../../domain/entities/Ref";
-import { SURVEYS_WITH_ORG_UNIT_SELECTOR, SURVEY_FORM_TYPES } from "../../../domain/entities/Survey";
+import {
+    SURVEYS_WITH_COUNTRY_LEVEL_OU,
+    SURVEYS_WITH_ORG_UNIT_SELECTOR,
+    SURVEY_FORM_TYPES,
+} from "../../../domain/entities/Survey";
 import { OrgUnitAccess, UserOrgUnit } from "../../../domain/entities/User";
 import { GLOBAL_OU_ID } from "../../../domain/usecases/SaveFormDataUseCase";
 import { getParentOUIdFromPath } from "../../../domain/utils/PPSProgramsHelper";
@@ -72,14 +76,8 @@ export const SurveyFormOUSelector: React.FC<SurveyFormOUSelectorProps> = ({
     ]);
 
     const selectableLevels = useMemo(() => {
-        switch (formType) {
-            case "PPSCountryQuestionnaire":
-            case "PrevalenceSurveyForm":
-            case "WardSummaryStatisticsForm":
-                return HOSPITAL_OU_LEVELS;
-            default:
-                return [COUNTRY_OU_LEVEL];
-        }
+        if (SURVEYS_WITH_COUNTRY_LEVEL_OU.includes(formType)) return [COUNTRY_OU_LEVEL];
+        return [HOSPITAL_OU_LEVELS];
     }, [formType]);
 
     return (

--- a/src/webapp/pages/survey/SurveyPage.tsx
+++ b/src/webapp/pages/survey/SurveyPage.tsx
@@ -22,7 +22,7 @@ export const SurveyPage: React.FC = () => {
             {currentModule?.name === "PPS" && (
                 <PPSSurveyFormBreadCrumb formType={formType} id={id} />
             )}
-            {currentModule?.name === "Prevalence" && (
+            {currentModule?.name === "Prevalence" && formType !== "WardSummaryStatisticsForm" && (
                 <PrevalenceSurveyFormBreadCrumb formType={formType} id={id} />
             )}
             <SurveyForm hideForm={hideForm} formType={formType} currentSurveyId={id} />


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869ba3dj4

### :memo: Implementation
- [x] Get unique ward ids used in ward summary by matching coc to the end of the ward id
- [x] Get user org unit root ids to use in ward summary form org unit selector

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/bc56ce69-1fdd-493d-86f9-99fe8c169fdd


### :fire: Notes to the tester



#869ba3dj4