### PR TITLE
Improve case report lists

### DIFF
--- a/.githooks/dep-check
+++ b/.githooks/dep-check
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-function changed {
+changed() {
   git diff --name-only HEAD@{1} HEAD | grep "^$1" > /dev/null 2>&1
 }
 

--- a/src/data/repositories/PaginatedSurveyD2Repository.ts
+++ b/src/data/repositories/PaginatedSurveyD2Repository.ts
@@ -10,6 +10,7 @@ import { getParentDataElementForProgram, isTrackerProgram } from "../utils/surve
 import {
     AMR_SURVEYS_PREVALENCE_TEA_SURVEY_ID_CRF,
     AMR_SURVEYS_PREVALENCE_TEA_UNIQUE_PATIENT_ID,
+    keyToDataElementMap,
     PPS_PATIENT_REGISTER_ID,
     PREVALENCE_CASE_REPORT_FORM_ID,
     SURVEY_PATIENT_CODE_TEA_ID,
@@ -25,6 +26,7 @@ import { getSurveyChildCount } from "../utils/surveyChildCountHelper";
 import { DataStoreClient } from "../DataStoreClient";
 import { AMRSurveyModule } from "../../domain/entities/AMRSurveyModule";
 import { DataStoreKeys } from "../DataStoreKeys";
+import { TrackedOrderBase } from "@eyeseetea/d2-api/api/trackerTrackedEntities";
 
 export class PaginatedSurveyD2Repository implements PaginatedSurveyRepository {
     modules: AMRSurveyModule[] = [];
@@ -46,7 +48,9 @@ export class PaginatedSurveyD2Repository implements PaginatedSurveyRepository {
         orgUnitId: Id,
         parentId: Id | undefined,
         page: number,
-        pageSize: number
+        pageSize: number,
+        sortPatientBy?: "patientId" | "patientCode",
+        sortDir?: "asc" | "desc"
     ): FutureData<PaginatedReponse<Survey[]>> {
         return isTrackerProgram(programId, this.modules)
             ? this.getTrackerProgramSurveys(
@@ -55,7 +59,9 @@ export class PaginatedSurveyD2Repository implements PaginatedSurveyRepository {
                   orgUnitId,
                   parentId,
                   page,
-                  pageSize
+                  pageSize,
+                  sortDir,
+                  sortPatientBy
               )
             : this.getEventProgramSurveys(
                   surveyFormType,
@@ -63,8 +69,36 @@ export class PaginatedSurveyD2Repository implements PaginatedSurveyRepository {
                   orgUnitId,
                   parentId,
                   page,
-                  pageSize
+                  pageSize,
+                  sortDir,
+                  sortPatientBy
               );
+    }
+
+    private buildOrderForTrackerEntitiesSort(
+        surveyFormType: SURVEY_FORM_TYPES,
+        sortDir?: "asc" | "desc",
+        sortPatientBy?: "patientId" | "patientCode"
+    ): TrackedOrderBase[] | undefined {
+        if (!sortDir) return undefined;
+
+        if (surveyFormType === "PrevalenceCaseReportForm") {
+            return [
+                {
+                    type: "trackedEntityAttributeId",
+                    id: AMR_SURVEYS_PREVALENCE_TEA_UNIQUE_PATIENT_ID,
+                    direction: sortDir,
+                },
+            ];
+        }
+        if (surveyFormType === "PPSPatientRegister") {
+            const effective = sortPatientBy ?? "patientId";
+            const id =
+                effective === "patientCode" ? SURVEY_PATIENT_CODE_TEA_ID : SURVEY_PATIENT_ID_TEA_ID;
+            return [{ type: "trackedEntityAttributeId", id, direction: sortDir }];
+        }
+
+        return undefined;
     }
 
     getTrackerProgramSurveys(
@@ -73,11 +107,15 @@ export class PaginatedSurveyD2Repository implements PaginatedSurveyRepository {
         orgUnitId: Id,
         parentId: Id | undefined,
         page: number,
-        pageSize: number
+        pageSize: number,
+        sortDir?: "asc" | "desc",
+        sortPatientBy?: "patientId" | "patientCode"
     ): FutureData<PaginatedReponse<Survey[]>> {
         const ouMode = "SELECTED";
 
         const filterParentDEId = getParentDataElementForProgram(programId, this.modules);
+
+        const order = this.buildOrderForTrackerEntitiesSort(surveyFormType, sortDir, sortPatientBy);
 
         return apiToFuture(
             this.api.tracker.trackedEntities.get({
@@ -89,6 +127,7 @@ export class PaginatedSurveyD2Repository implements PaginatedSurveyRepository {
                 pageSize,
                 totalPages: true,
                 filter: `${filterParentDEId}:eq:${parentId}`,
+                ...(order ? { order: order } : {}),
             })
         ).flatMap(trackedEntities => {
             const instances = trackedEntities.instances;
@@ -107,15 +146,33 @@ export class PaginatedSurveyD2Repository implements PaginatedSurveyRepository {
         });
     }
 
+    private getDataElementUidForEventSort(
+        surveyFormType: SURVEY_FORM_TYPES,
+        sortPatientBy?: "patientId" | "patientCode"
+    ): string | undefined {
+        const effectiveSortBy =
+            surveyFormType === "PrevalenceCaseReportForm"
+                ? "patientId"
+                : sortPatientBy ?? "patientId";
+
+        const entry = keyToDataElementMap.find(m => m.key === effectiveSortBy);
+        return entry?.dataElements?.[0];
+    }
+
     getEventProgramSurveys(
         surveyFormType: SURVEY_FORM_TYPES,
         programId: Id,
         orgUnitId: Id,
         parentId: Id | undefined,
         page: number,
-        pageSize: number
+        pageSize: number,
+        sortDir?: "asc" | "desc",
+        sortPatientBy?: "patientId" | "patientCode"
     ): FutureData<PaginatedReponse<Survey[]>> {
         const ouMode = "SELECTED";
+        const dataElementUid = this.getDataElementUidForEventSort(surveyFormType, sortPatientBy);
+        const order = sortDir && dataElementUid ? `${dataElementUid}:${sortDir}` : undefined;
+
         return apiToFuture(
             this.api.tracker.events.get({
                 fields: { $all: true },
@@ -126,6 +183,7 @@ export class PaginatedSurveyD2Repository implements PaginatedSurveyRepository {
                 pageSize,
                 totalPages: true,
                 filter: `${WARD_ID_TEA_ID}:eq:${parentId}`,
+                ...(order ? { order: order } : {}),
             })
         ).flatMap(response => {
             const events = response.instances;

--- a/src/data/repositories/SurveyFormD2Repository.ts
+++ b/src/data/repositories/SurveyFormD2Repository.ts
@@ -5,7 +5,12 @@ import { SurveyRepository } from "../../domain/repositories/SurveyRepository";
 import { apiToFuture, FutureData } from "../api-futures";
 import _ from "../../domain/entities/generic/Collection";
 import { ImportStrategy } from "../../domain/entities/Program";
-import { ChildCount, Survey, SURVEY_FORM_TYPES } from "../../domain/entities/Survey";
+import {
+    ChildCount,
+    Survey,
+    SURVEY_FORM_TYPES,
+    SurveyParentDetails,
+} from "../../domain/entities/Survey";
 import {
     TrackedEntitiesGetResponse,
     D2TrackedEntityInstanceToPost,
@@ -42,7 +47,6 @@ import {
     trackedEntityFields,
 } from "../utils/surveyListMappers";
 import { Questionnaire } from "../../domain/entities/Questionnaire/Questionnaire";
-import { ASTGUIDELINE_TYPES } from "../../domain/entities/ASTGuidelines";
 import { getSurveyChildCount } from "../utils/surveyChildCountHelper";
 import { TrackerPostRequest, TrackerPostResponse } from "@eyeseetea/d2-api/api/tracker";
 import { Maybe } from "../../utils/ts-utils";
@@ -477,7 +481,7 @@ export class SurveyD2Repository implements SurveyRepository {
     getSurveyNameAndASTGuidelineFromId(
         id: Id,
         surveyFormType: SURVEY_FORM_TYPES
-    ): FutureData<{ name: string; astGuidelineType?: ASTGUIDELINE_TYPES }> {
+    ): FutureData<SurveyParentDetails> {
         const parentSurveyType = getSurveyType(surveyFormType);
 
         return this.getEventProgramById(id)

--- a/src/data/repositories/testRepositories/PaginatedSurveyTestRepository.ts
+++ b/src/data/repositories/testRepositories/PaginatedSurveyTestRepository.ts
@@ -33,7 +33,9 @@ export class PaginatedSurveyTestRepository implements PaginatedSurveyRepository 
         orgUnitId: string,
         parentWardRegisterId: string | undefined,
         page: number,
-        pageSize: number
+        pageSize: number,
+        sortPatientBy?: "patientId" | "patientCode",
+        sortDir?: "asc" | "desc"
     ): FutureData<PaginatedReponse<Survey[]>> {
         throw new Error("Method not implemented.");
     }

--- a/src/domain/entities/Survey.ts
+++ b/src/domain/entities/Survey.ts
@@ -94,3 +94,5 @@ export interface Survey extends SurveyBase {
     childCount?: ChildCountLabel;
     facilityCode?: string;
 }
+
+export type SurveyParentDetails = { name: string; astGuidelineType?: ASTGUIDELINE_TYPES };

--- a/src/domain/repositories/PaginatedSurveyRepository.ts
+++ b/src/domain/repositories/PaginatedSurveyRepository.ts
@@ -10,7 +10,9 @@ export interface PaginatedSurveyRepository {
         orgUnitId: Id,
         parentWardRegisterId: Id | undefined,
         page: number,
-        pageSize: number
+        pageSize: number,
+        sortPatientBy?: "patientId" | "patientCode",
+        sortDir?: "asc" | "desc"
     ): FutureData<PaginatedReponse<Survey[]>>;
     getFilteredPPSPatientByPatientIdSurveys(
         keyword: string,

--- a/src/domain/repositories/SurveyRepository.ts
+++ b/src/domain/repositories/SurveyRepository.ts
@@ -1,9 +1,8 @@
 import { FutureData } from "../../data/api-futures";
-import { ASTGUIDELINE_TYPES } from "../entities/ASTGuidelines";
 import { ImportStrategy } from "../entities/Program";
 import { Questionnaire } from "../entities/Questionnaire/Questionnaire";
 import { Id } from "../entities/Ref";
-import { ChildCount, Survey, SURVEY_FORM_TYPES } from "../entities/Survey";
+import { ChildCount, SurveyParentDetails, Survey, SURVEY_FORM_TYPES } from "../entities/Survey";
 
 export interface SurveyRepository {
     getForm(
@@ -31,7 +30,7 @@ export interface SurveyRepository {
     getSurveyNameAndASTGuidelineFromId(
         id: Id,
         surveyFormType: SURVEY_FORM_TYPES
-    ): FutureData<{ name: string; astGuidelineType?: ASTGUIDELINE_TYPES }>;
+    ): FutureData<SurveyParentDetails>;
 
     getNonPaginatedSurveyChildCount(
         parentProgram: Id,

--- a/src/domain/usecases/GetPaginatedSurveysUseCase.ts
+++ b/src/domain/usecases/GetPaginatedSurveysUseCase.ts
@@ -1,6 +1,6 @@
 import { FutureData } from "../../data/api-futures";
 import { Id } from "../entities/Ref";
-import { Survey, SURVEY_FORM_TYPES, SurveyBase } from "../entities/Survey";
+import { SurveyParentDetails, Survey, SURVEY_FORM_TYPES, SurveyBase } from "../entities/Survey";
 import { isPrevalencePatientChild } from "../utils/PPSProgramsHelper";
 import { PaginatedReponse } from "../entities/TablePagination";
 import { PaginatedSurveyRepository } from "../repositories/PaginatedSurveyRepository";
@@ -52,13 +52,27 @@ export class GetPaginatedSurveysUseCase {
             return this.paginatedSurveyRepo
                 .getSurveys(surveyFormType, programId, orgUnitId, parentId, page, pageSize)
                 .flatMap(surveys => {
-                    const surveysWithName = surveys.objects.map(survey => {
-                        return Future.join2(
-                            this.surveyReporsitory.getSurveyNameAndASTGuidelineFromId(
-                                survey.rootSurvey.id,
-                                survey.surveyFormType
-                            ),
-                            getChildCount({
+                    if (surveys.objects.length === 0) return Future.success(surveys);
+
+                    const $surveyParentDetails: Array<
+                        FutureData<readonly [Id, SurveyParentDetails]>
+                    > = _(surveys.objects)
+                        .groupBy(s => s.rootSurvey.id)
+                        .toPairs()
+                        .map(([rootSurveyId]) =>
+                            this.surveyReporsitory
+                                .getSurveyNameAndASTGuidelineFromId(rootSurveyId, surveyFormType)
+                                .map(details => [rootSurveyId, details] as const)
+                        );
+
+                    const $surveyParentDetailsByRootId: FutureData<Map<Id, SurveyParentDetails>> =
+                        Future.parallel($surveyParentDetails, { concurrency: 5 }).map(
+                            pairs => new Map<Id, SurveyParentDetails>(pairs)
+                        );
+
+                    return $surveyParentDetailsByRootId.flatMap(parentDetailsMap => {
+                        const surveysWithName = surveys.objects.map(survey => {
+                            return getChildCount({
                                 surveyFormType: surveyFormType,
                                 orgUnitId: survey.assignedOrgUnit.id,
                                 parentSurveyId: survey.rootSurvey.id,
@@ -67,39 +81,37 @@ export class GetPaginatedSurveysUseCase {
                                 programId: programId,
                                 modules: modules,
                                 currentModule: currentModule,
-                            })
-                        ).map(([parentDetails, childCount]): Survey => {
-                            const newRootSurvey: SurveyBase = {
-                                surveyType: survey.rootSurvey.surveyType,
-                                id: survey.rootSurvey.id,
-                                name:
-                                    survey.rootSurvey.name === ""
-                                        ? parentDetails.name
-                                        : survey.rootSurvey.name,
-                            };
+                            }).map((childCount): Survey => {
+                                const parentDetails = parentDetailsMap.get(survey.rootSurvey.id);
 
-                            const updatedSurvey: Survey = {
-                                ...survey,
-                                name:
-                                    surveyFormType === "PrevalenceCaseReportForm"
-                                        ? survey.uniquePatient?.id ?? survey.name
-                                        : survey.name,
-                                rootSurvey: newRootSurvey,
-                                childCount: childCount,
-                            };
-                            return updatedSurvey;
+                                const newRootSurvey: SurveyBase = {
+                                    surveyType: survey.rootSurvey.surveyType,
+                                    id: survey.rootSurvey.id,
+                                    name:
+                                        survey.rootSurvey.name === ""
+                                            ? parentDetails?.name ?? ""
+                                            : survey.rootSurvey.name,
+                                };
+
+                                return {
+                                    ...survey,
+                                    name:
+                                        surveyFormType === "PrevalenceCaseReportForm"
+                                            ? survey.uniquePatient?.id ?? survey.name
+                                            : survey.name,
+                                    rootSurvey: newRootSurvey,
+                                    childCount: childCount,
+                                };
+                            });
                         });
-                    });
 
-                    return Future.parallel(surveysWithName, { concurrency: 5 }).map(
-                        updatedSurveys => {
-                            const paginatedSurveys: PaginatedReponse<Survey[]> = {
+                        return Future.parallel(surveysWithName, { concurrency: 5 }).map(
+                            updatedSurveys => ({
                                 pager: surveys.pager,
                                 objects: updatedSurveys,
-                            };
-                            return paginatedSurveys;
-                        }
-                    );
+                            })
+                        );
+                    });
                 });
         });
     }

--- a/src/domain/usecases/GetPaginatedSurveysUseCase.ts
+++ b/src/domain/usecases/GetPaginatedSurveysUseCase.ts
@@ -21,6 +21,8 @@ type GetPaginatedSurveysOptions = {
     page: number;
     pageSize: number;
     currentModule?: AMRSurveyModule;
+    sortDir?: "asc" | "desc";
+    sortPatientBy?: "patientId" | "patientCode";
 };
 
 export class GetPaginatedSurveysUseCase {
@@ -39,6 +41,8 @@ export class GetPaginatedSurveysUseCase {
         page,
         pageSize,
         currentModule,
+        sortPatientBy,
+        sortDir,
     }: GetPaginatedSurveysOptions): FutureData<PaginatedReponse<Survey[]>> {
         return this.moduleRepository.getAll().flatMap(modules => {
             const programId = getProgramId(surveyFormType, parentSurveyId, modules);
@@ -50,7 +54,16 @@ export class GetPaginatedSurveysUseCase {
                 : parentSurveyId;
 
             return this.paginatedSurveyRepo
-                .getSurveys(surveyFormType, programId, orgUnitId, parentId, page, pageSize)
+                .getSurveys(
+                    surveyFormType,
+                    programId,
+                    orgUnitId,
+                    parentId,
+                    page,
+                    pageSize,
+                    sortPatientBy,
+                    sortDir
+                )
                 .flatMap(surveys => {
                     if (surveys.objects.length === 0) return Future.success(surveys);
 

--- a/src/webapp/components/survey-list/SurveyList.tsx
+++ b/src/webapp/components/survey-list/SurveyList.tsx
@@ -43,6 +43,11 @@ export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
         total,
         setTotal,
         setRefreshSurveys,
+        directionSortPatientId,
+        setDirectionSortPatientId,
+        directionSortPatientCode,
+        setDirectionSortPatientCode,
+        setSortPatientBy,
     } = useSurveys(surveyFormType);
 
     const {
@@ -175,6 +180,11 @@ export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
                             setPageSize={setPageSize}
                             total={total}
                             refreshSurveys={setRefreshSurveys}
+                            setSortPatientBy={setSortPatientBy}
+                            setPatientIdDir={setDirectionSortPatientId}
+                            patientIdDir={directionSortPatientId}
+                            setPatientCodeDir={setDirectionSortPatientCode}
+                            patientCodeDir={directionSortPatientCode}
                         />
                     ) : (
                         <SurveyListTable

--- a/src/webapp/components/survey-list/SurveyList.tsx
+++ b/src/webapp/components/survey-list/SurveyList.tsx
@@ -39,6 +39,7 @@ export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
         page,
         setPage,
         pageSize,
+        setPageSize,
         total,
         setTotal,
         setRefreshSurveys,
@@ -171,6 +172,7 @@ export const SurveyList: React.FC<SurveyListProps> = ({ surveyFormType }) => {
                             page={page}
                             setPage={setPage}
                             pageSize={pageSize}
+                            setPageSize={setPageSize}
                             total={total}
                             refreshSurveys={setRefreshSurveys}
                         />

--- a/src/webapp/components/survey-list/hook/useMultipleChildCount.ts
+++ b/src/webapp/components/survey-list/hook/useMultipleChildCount.ts
@@ -17,6 +17,13 @@ export const useMultipleChildCount = (
         useState<SortDirection>("asc");
     const [supranationalRefsResultsSortDirection, setSupranationalRefsResultsSortDirection] =
         useState<SortDirection>("asc");
+    const [followUpSortDirection, setFollowUpSortDirection] = useState<SortDirection>("asc");
+    const [dischargeClinicalSortDirection, setDischargeClinicalSortDirection] =
+        useState<SortDirection>("asc");
+    const [dischargeEconomicSortDirection, setDischargeEconomicSortDirection] =
+        useState<SortDirection>("asc");
+    const [cohortEnrolmentSortDirection, setCohortEnrolmentSortDirection] =
+        useState<SortDirection>("asc");
 
     const getCurrentSortDirection = (childOptionName: string): SortDirection => {
         switch (childOptionName) {
@@ -29,10 +36,13 @@ export const useMultipleChildCount = (
             case "Supranational Ref Results":
                 return supranationalRefsResultsSortDirection;
             case "Follow-up":
+                return followUpSortDirection;
             case "Discharge - Clinical":
+                return dischargeClinicalSortDirection;
             case "Discharge - Economic":
+                return dischargeEconomicSortDirection;
             case "Cohort enrolment":
-                return "asc";
+                return cohortEnrolmentSortDirection;
 
             default:
                 throw new Error(`Invalid child option name: ${childOptionName}`);
@@ -72,6 +82,34 @@ export const useMultipleChildCount = (
                     setSupranationalRefsResultsSortDirection(nextDir);
                     sortByColumn("childCount", nextDir, childIndex);
                 };
+            case "Follow-up":
+                return () => {
+                    const nextDir: SortDirection = followUpSortDirection === "asc" ? "desc" : "asc";
+                    setFollowUpSortDirection(nextDir);
+                    sortByColumn("childCount", nextDir, childIndex);
+                };
+            case "Discharge - Clinical":
+                return () => {
+                    const nextDir: SortDirection =
+                        dischargeClinicalSortDirection === "asc" ? "desc" : "asc";
+                    setDischargeClinicalSortDirection(nextDir);
+                    sortByColumn("childCount", nextDir, childIndex);
+                };
+            case "Discharge - Economic":
+                return () => {
+                    const nextDir: SortDirection =
+                        dischargeEconomicSortDirection === "asc" ? "desc" : "asc";
+                    setDischargeEconomicSortDirection(nextDir);
+                    sortByColumn("childCount", nextDir, childIndex);
+                };
+            case "Cohort enrolment":
+                return () => {
+                    const nextDir: SortDirection =
+                        cohortEnrolmentSortDirection === "asc" ? "desc" : "asc";
+                    setCohortEnrolmentSortDirection(nextDir);
+                    sortByColumn("childCount", nextDir, childIndex);
+                };
+
             default:
                 return undefined;
         }

--- a/src/webapp/components/survey-list/hook/useMultipleChildCount.ts
+++ b/src/webapp/components/survey-list/hook/useMultipleChildCount.ts
@@ -6,7 +6,7 @@ export const useMultipleChildCount = (
     sortByColumn: (
         columnName: keyof Survey,
         sortDirection: SortDirection,
-        childLabel?: string
+        childIndex?: number
     ) => void
 ) => {
     const [sampleShipmentsSortDirection, setSampleShipmentsSortDirection] =
@@ -39,35 +39,38 @@ export const useMultipleChildCount = (
         }
     };
 
-    const childOnClick = (childOptionName: string): MouseEventHandler | undefined => {
+    const childOnClick = (
+        childOptionName: string,
+        childIndex: number
+    ): MouseEventHandler | undefined => {
         switch (childOptionName) {
             case "Sample Shipment":
                 return () => {
                     const nextDir: SortDirection =
                         sampleShipmentsSortDirection === "asc" ? "desc" : "asc";
                     setSampleShipmentsSortDirection(nextDir);
-                    sortByColumn("childCount", nextDir, "Sample Shipment");
+                    sortByColumn("childCount", nextDir, childIndex);
                 };
             case "Central Ref Lab Results":
                 return () => {
                     const nextDir: SortDirection =
                         centralRefLabsResultsSortDirection === "asc" ? "desc" : "asc";
                     setCentralRefLabsResultsSortDirection(nextDir);
-                    sortByColumn("childCount", nextDir, "Central Ref Lab Results");
+                    sortByColumn("childCount", nextDir, childIndex);
                 };
             case "Pathogen Isolates Logs":
                 return () => {
                     const nextDir: SortDirection =
                         pathogenIsolatesLogsSortDirection === "asc" ? "desc" : "asc";
                     setPathogenIsolatesLogsSortDirection(nextDir);
-                    sortByColumn("childCount", nextDir, "Pathogen Isolates Logs");
+                    sortByColumn("childCount", nextDir, childIndex);
                 };
             case "Supranational Ref Results":
                 return () => {
                     const nextDir: SortDirection =
                         supranationalRefsResultsSortDirection === "asc" ? "desc" : "asc";
                     setSupranationalRefsResultsSortDirection(nextDir);
-                    sortByColumn("childCount", nextDir, "Supranational Ref Results");
+                    sortByColumn("childCount", nextDir, childIndex);
                 };
             default:
                 return undefined;

--- a/src/webapp/components/survey-list/hook/useMultipleChildCount.ts
+++ b/src/webapp/components/survey-list/hook/useMultipleChildCount.ts
@@ -3,7 +3,11 @@ import { SortDirection } from "../table/PaginatedSurveyListTable";
 import { Survey } from "../../../../domain/entities/Survey";
 
 export const useMultipleChildCount = (
-    sortByColumn: (columnName: keyof Survey, sortDirection: SortDirection) => void
+    sortByColumn: (
+        columnName: keyof Survey,
+        sortDirection: SortDirection,
+        childLabel?: string
+    ) => void
 ) => {
     const [sampleShipmentsSortDirection, setSampleShipmentsSortDirection] =
         useState<SortDirection>("asc");
@@ -39,31 +43,31 @@ export const useMultipleChildCount = (
         switch (childOptionName) {
             case "Sample Shipment":
                 return () => {
-                    sampleShipmentsSortDirection === "asc"
-                        ? setSampleShipmentsSortDirection("desc")
-                        : setSampleShipmentsSortDirection("asc");
-                    sortByColumn("childCount", sampleShipmentsSortDirection);
+                    const nextDir: SortDirection =
+                        sampleShipmentsSortDirection === "asc" ? "desc" : "asc";
+                    setSampleShipmentsSortDirection(nextDir);
+                    sortByColumn("childCount", nextDir, "Sample Shipment");
                 };
             case "Central Ref Lab Results":
                 return () => {
-                    centralRefLabsResultsSortDirection === "asc"
-                        ? setCentralRefLabsResultsSortDirection("desc")
-                        : setCentralRefLabsResultsSortDirection("asc");
-                    sortByColumn("childCount", centralRefLabsResultsSortDirection);
+                    const nextDir: SortDirection =
+                        centralRefLabsResultsSortDirection === "asc" ? "desc" : "asc";
+                    setCentralRefLabsResultsSortDirection(nextDir);
+                    sortByColumn("childCount", nextDir, "Central Ref Lab Results");
                 };
             case "Pathogen Isolates Logs":
                 return () => {
-                    pathogenIsolatesLogsSortDirection === "asc"
-                        ? setPathogenIsolatesLogsSortDirection("desc")
-                        : setPathogenIsolatesLogsSortDirection("asc");
-                    sortByColumn("childCount", pathogenIsolatesLogsSortDirection);
+                    const nextDir: SortDirection =
+                        pathogenIsolatesLogsSortDirection === "asc" ? "desc" : "asc";
+                    setPathogenIsolatesLogsSortDirection(nextDir);
+                    sortByColumn("childCount", nextDir, "Pathogen Isolates Logs");
                 };
             case "Supranational Ref Results":
                 return () => {
-                    supranationalRefsResultsSortDirection === "asc"
-                        ? setSupranationalRefsResultsSortDirection("desc")
-                        : setSupranationalRefsResultsSortDirection("asc");
-                    sortByColumn("childCount", supranationalRefsResultsSortDirection);
+                    const nextDir: SortDirection =
+                        supranationalRefsResultsSortDirection === "asc" ? "desc" : "asc";
+                    setSupranationalRefsResultsSortDirection(nextDir);
+                    sortByColumn("childCount", nextDir, "Supranational Ref Results");
                 };
             default:
                 return undefined;

--- a/src/webapp/components/survey-list/hook/useSurveyListActions.ts
+++ b/src/webapp/components/survey-list/hook/useSurveyListActions.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useHistory } from "react-router-dom";
 import {
     Survey,
@@ -161,14 +161,43 @@ export function useSurveyListActions(surveyFormType: SURVEY_FORM_TYPES) {
         }
     };
 
-    const sortByColumn = (columnName: keyof Survey, sortDirection: SortDirection) => {
-        setSortedSurveys(surveys => {
-            if (surveys)
-                return _(surveys)
-                    .sortBy(x => x[columnName], { direction: sortDirection })
+    const sortByColumn = useCallback(
+        (columnName: keyof Survey, sortDirection: SortDirection, childLabel?: string) => {
+            setSortedSurveys(prevSurveys => {
+                if (!prevSurveys) return prevSurveys;
+
+                const getChildValue = (survey: Survey) => {
+                    const count = survey.childCount;
+                    if (!count) return 0;
+
+                    if (count.type === "number") return Number(count.value ?? 0);
+
+                    if (count.type === "map") {
+                        const item = (count.value ?? []).find(value =>
+                            value?.option?.label
+                                ?.toLowerCase()
+                                .trim()
+                                .includes(childLabel?.toLowerCase().trim() ?? "")
+                        );
+                        return Number(item?.count ?? 0);
+                    }
+                    return 0;
+                };
+
+                const getValue = (survey: Survey) => {
+                    if (columnName === "childCount") {
+                        return childLabel ? getChildValue(survey) : 0;
+                    }
+                    return survey[columnName];
+                };
+
+                return _(prevSurveys)
+                    .sortBy(s => getValue(s), { direction: sortDirection })
                     .value();
-        });
-    };
+            });
+        },
+        []
+    );
 
     const updateSelectedSurveyDetails = (
         survey: SurveyBase,

--- a/src/webapp/components/survey-list/hook/useSurveyListActions.ts
+++ b/src/webapp/components/survey-list/hook/useSurveyListActions.ts
@@ -165,7 +165,7 @@ export function useSurveyListActions(surveyFormType: SURVEY_FORM_TYPES) {
     };
 
     const sortByColumn = useCallback(
-        (columnName: SortableColumn, sortDirection: SortDirection, childLabel?: string) => {
+        (columnName: SortableColumn, sortDirection: SortDirection, childIndex?: number) => {
             setSortedSurveys(prevSurveys => {
                 if (!prevSurveys) return prevSurveys;
 
@@ -176,31 +176,19 @@ export function useSurveyListActions(surveyFormType: SURVEY_FORM_TYPES) {
                     if (count.type === "number") return Number(count.value ?? 0);
 
                     if (count.type === "map") {
-                        const item = (count.value ?? []).find(value =>
-                            value?.option?.label
-                                ?.toLowerCase()
-                                .trim()
-                                .includes(childLabel?.toLowerCase().trim() ?? "")
-                        );
+                        if (childIndex == null) return 0;
+                        const item = (count.value ?? [])[childIndex];
                         return Number(item?.count ?? 0);
                     }
                     return 0;
                 };
 
                 const getValue = (survey: Survey) => {
-                    if (columnName === "childCount") {
-                        return childLabel ? getChildValue(survey) : 0;
-                    }
-
-                    if (columnName === "uniquePatient.id") {
-                        return survey.uniquePatient?.id ?? "";
-                    }
-
-                    if (columnName === "uniquePatient.code") {
+                    if (columnName === "childCount") return getChildValue(survey);
+                    if (columnName === "uniquePatient.id") return survey.uniquePatient?.id ?? "";
+                    if (columnName === "uniquePatient.code")
                         return survey.uniquePatient?.code ?? "";
-                    }
-
-                    return survey[columnName as keyof Survey];
+                    return survey[columnName];
                 };
 
                 return _(prevSurveys)

--- a/src/webapp/components/survey-list/hook/useSurveyListActions.ts
+++ b/src/webapp/components/survey-list/hook/useSurveyListActions.ts
@@ -22,6 +22,9 @@ import { OrgUnitBasic } from "../../../../domain/entities/OrgUnit";
 import { getChildrenName } from "../../../../domain/utils/getChildrenName";
 
 export type SortDirection = "asc" | "desc";
+
+type SortableColumn = keyof Survey | "uniquePatient.id" | "uniquePatient.code";
+
 export function useSurveyListActions(surveyFormType: SURVEY_FORM_TYPES) {
     const { compositionRoot } = useAppContext();
     const history = useHistory();
@@ -162,7 +165,7 @@ export function useSurveyListActions(surveyFormType: SURVEY_FORM_TYPES) {
     };
 
     const sortByColumn = useCallback(
-        (columnName: keyof Survey, sortDirection: SortDirection, childLabel?: string) => {
+        (columnName: SortableColumn, sortDirection: SortDirection, childLabel?: string) => {
             setSortedSurveys(prevSurveys => {
                 if (!prevSurveys) return prevSurveys;
 
@@ -188,7 +191,16 @@ export function useSurveyListActions(surveyFormType: SURVEY_FORM_TYPES) {
                     if (columnName === "childCount") {
                         return childLabel ? getChildValue(survey) : 0;
                     }
-                    return survey[columnName];
+
+                    if (columnName === "uniquePatient.id") {
+                        return survey.uniquePatient?.id ?? "";
+                    }
+
+                    if (columnName === "uniquePatient.code") {
+                        return survey.uniquePatient?.code ?? "";
+                    }
+
+                    return survey[columnName as keyof Survey];
                 };
 
                 return _(prevSurveys)

--- a/src/webapp/components/survey-list/table/PaginatedSurveyListTable.tsx
+++ b/src/webapp/components/survey-list/table/PaginatedSurveyListTable.tsx
@@ -37,6 +37,11 @@ interface PaginatedSurveyListTableProps {
     setPageSize: Dispatch<SetStateAction<number>>;
     pageSize: number;
     total?: number;
+    setSortPatientBy: Dispatch<SetStateAction<"patientId" | "patientCode">>;
+    patientIdDir: "asc" | "desc";
+    setPatientIdDir: Dispatch<SetStateAction<"asc" | "desc">>;
+    patientCodeDir: "asc" | "desc";
+    setPatientCodeDir: Dispatch<SetStateAction<"asc" | "desc">>;
 }
 
 export type SortDirection = "asc" | "desc";
@@ -49,12 +54,15 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
     pageSize,
     setPageSize,
     total,
+    setSortPatientBy,
+    patientIdDir,
+    setPatientIdDir,
+    patientCodeDir,
+    setPatientCodeDir,
 }) => {
     const { snackbar, offlineError } = useOfflineSnackbar();
     //states for column sort
     const [surveyNameSortDirection, setSurveyNameSortDirection] = useState<SortDirection>("asc");
-    const [patientIdSortDirection, setPatientIdSortDirection] = useState<SortDirection>("asc");
-    const [patientCodeSortDirection, setPatientCodeSortDirection] = useState<SortDirection>("asc");
 
     const { deleteSurvey, loading, deleteCompleteState } = useDeleteSurvey(
         surveyFormType,
@@ -129,19 +137,18 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                                         isPrevalencePatientChild(surveyFormType)) && (
                                         <TableCell
                                             onClick={() => {
-                                                const nextDir: SortDirection =
-                                                    patientIdSortDirection === "asc"
-                                                        ? "desc"
-                                                        : "asc";
-                                                setPatientIdSortDirection(nextDir);
-                                                sortByColumn("uniquePatient.id", nextDir);
+                                                const nextDir =
+                                                    patientIdDir === "asc" ? "desc" : "asc";
+                                                setSortPatientBy("patientId");
+                                                setPatientIdDir(nextDir);
+                                                setPage(0);
                                             }}
                                         >
                                             <span>
                                                 <Typography variant="caption">
                                                     {i18n.t("Patient Id")}
                                                 </Typography>
-                                                {patientIdSortDirection === "asc" ? (
+                                                {patientIdDir === "asc" ? (
                                                     <ArrowUpward fontSize="small" />
                                                 ) : (
                                                     <ArrowDownward fontSize="small" />
@@ -152,19 +159,18 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                                     {surveyFormType === "PPSPatientRegister" && (
                                         <TableCell
                                             onClick={() => {
-                                                const nextDir: SortDirection =
-                                                    patientCodeSortDirection === "asc"
-                                                        ? "desc"
-                                                        : "asc";
-                                                setPatientCodeSortDirection(nextDir);
-                                                sortByColumn("uniquePatient.code", nextDir);
+                                                const nextDir =
+                                                    patientCodeDir === "asc" ? "desc" : "asc";
+                                                setSortPatientBy("patientCode");
+                                                setPatientCodeDir(nextDir);
+                                                setPage(0);
                                             }}
                                         >
                                             <span>
                                                 <Typography variant="caption">
                                                     {i18n.t("Patient Code")}
                                                 </Typography>
-                                                {patientCodeSortDirection === "asc" ? (
+                                                {patientCodeDir === "asc" ? (
                                                     <ArrowUpward fontSize="small" />
                                                 ) : (
                                                     <ArrowDownward fontSize="small" />
@@ -174,9 +180,9 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                                     )}
 
                                     <>
-                                        {columnNames.map(childName => (
+                                        {columnNames.map((childName, childIndex) => (
                                             <TableCell
-                                                onClick={childOnClick(childName)}
+                                                onClick={childOnClick(childName, childIndex)}
                                                 key={childName}
                                             >
                                                 <span>

--- a/src/webapp/components/survey-list/table/PaginatedSurveyListTable.tsx
+++ b/src/webapp/components/survey-list/table/PaginatedSurveyListTable.tsx
@@ -134,7 +134,7 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                                                         ? "desc"
                                                         : "asc";
                                                 setPatientIdSortDirection(nextDir);
-                                                sortByColumn("name", nextDir);
+                                                sortByColumn("uniquePatient.id", nextDir);
                                             }}
                                         >
                                             <span>
@@ -157,10 +157,7 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                                                         ? "desc"
                                                         : "asc";
                                                 setPatientCodeSortDirection(nextDir);
-                                                sortByColumn(
-                                                    "uniquePatient.code" as keyof Survey,
-                                                    nextDir
-                                                );
+                                                sortByColumn("uniquePatient.code", nextDir);
                                             }}
                                         >
                                             <span>

--- a/src/webapp/components/survey-list/table/PaginatedSurveyListTable.tsx
+++ b/src/webapp/components/survey-list/table/PaginatedSurveyListTable.tsx
@@ -359,7 +359,7 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                     </TableContainer>
 
                     <TablePagination
-                        rowsPerPageOptions={[1, 10, 25]}
+                        rowsPerPageOptions={[10, 25, 50]}
                         component="div"
                         count={total || 0}
                         rowsPerPage={pageSize}

--- a/src/webapp/components/survey-list/table/PaginatedSurveyListTable.tsx
+++ b/src/webapp/components/survey-list/table/PaginatedSurveyListTable.tsx
@@ -18,7 +18,7 @@ import {
 import i18n from "@eyeseetea/feedback-component/locales";
 import { ActionMenuButton } from "../../action-menu-button/ActionMenuButton";
 import { palette } from "../../../pages/app/themes/dhis2.theme";
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, useCallback, useEffect, useState } from "react";
 import { ArrowDownward, ArrowUpward } from "@material-ui/icons";
 import _ from "../../../../domain/entities/generic/Collection";
 import { useDeleteSurvey } from "../hook/useDeleteSurvey";
@@ -34,6 +34,7 @@ interface PaginatedSurveyListTableProps {
     refreshSurveys: Dispatch<SetStateAction<{}>>;
     page: number;
     setPage: Dispatch<SetStateAction<number>>;
+    setPageSize: Dispatch<SetStateAction<number>>;
     pageSize: number;
     total?: number;
 }
@@ -46,6 +47,7 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
     page,
     setPage,
     pageSize,
+    setPageSize,
     total,
 }) => {
     const { snackbar, offlineError } = useOfflineSnackbar();
@@ -84,6 +86,16 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
         }
     }, [deleteCompleteState, snackbar, surveys, offlineError, setSortedSurveys]);
 
+    const handleChangeRowsPerPage = useCallback(
+        (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+            const nextPageSize = parseInt(event.target.value, 10);
+            setPageSize(nextPageSize);
+            setPage(0);
+            localStorage.setItem("pageSize", String(nextPageSize));
+        },
+        [setPage, setPageSize]
+    );
+
     return (
         <ContentLoader loading={loading} error="" showErrorAsSnackbar={false}>
             {sortedSurveys && (
@@ -94,10 +106,10 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                                 <TableRow>
                                     <TableCell
                                         onClick={() => {
-                                            surveyNameSortDirection === "asc"
-                                                ? setSurveyNameSortDirection("desc")
-                                                : setSurveyNameSortDirection("asc");
-                                            sortByColumn("name", surveyNameSortDirection);
+                                            const nextDir: SortDirection =
+                                                surveyNameSortDirection === "asc" ? "desc" : "asc";
+                                            setSurveyNameSortDirection(nextDir);
+                                            sortByColumn("name", nextDir);
                                         }}
                                     >
                                         <span>
@@ -117,13 +129,12 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                                         isPrevalencePatientChild(surveyFormType)) && (
                                         <TableCell
                                             onClick={() => {
-                                                patientIdSortDirection === "asc"
-                                                    ? setPatientIdSortDirection("desc")
-                                                    : setPatientIdSortDirection("asc");
-                                                sortByColumn(
-                                                    "uniquePatient.id" as keyof Survey,
-                                                    patientIdSortDirection
-                                                );
+                                                const nextDir: SortDirection =
+                                                    patientIdSortDirection === "asc"
+                                                        ? "desc"
+                                                        : "asc";
+                                                setPatientIdSortDirection(nextDir);
+                                                sortByColumn("name", nextDir);
                                             }}
                                         >
                                             <span>
@@ -141,12 +152,14 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                                     {surveyFormType === "PPSPatientRegister" && (
                                         <TableCell
                                             onClick={() => {
-                                                patientCodeSortDirection === "asc"
-                                                    ? setPatientCodeSortDirection("desc")
-                                                    : setPatientCodeSortDirection("asc");
+                                                const nextDir: SortDirection =
+                                                    patientCodeSortDirection === "asc"
+                                                        ? "desc"
+                                                        : "asc";
+                                                setPatientCodeSortDirection(nextDir);
                                                 sortByColumn(
                                                     "uniquePatient.code" as keyof Survey,
-                                                    patientCodeSortDirection
+                                                    nextDir
                                                 );
                                             }}
                                         >
@@ -346,12 +359,13 @@ export const PaginatedSurveyListTable: React.FC<PaginatedSurveyListTableProps> =
                     </TableContainer>
 
                     <TablePagination
-                        rowsPerPageOptions={[]}
+                        rowsPerPageOptions={[1, 10, 25]}
                         component="div"
                         count={total || 0}
                         rowsPerPage={pageSize}
                         page={page}
                         onPageChange={(_e, page) => setPage(page)}
+                        onRowsPerPageChange={handleChangeRowsPerPage}
                     />
                 </TableContentWrapper>
             )}

--- a/src/webapp/components/survey-list/table/SurveyListTable.tsx
+++ b/src/webapp/components/survey-list/table/SurveyListTable.tsx
@@ -87,10 +87,10 @@ export const SurveyListTable: React.FC<SurveyListTableProps> = ({
                                 <TableRow>
                                     <TableCell
                                         onClick={() => {
-                                            surveyNameSortDirection === "asc"
-                                                ? setSurveyNameSortDirection("desc")
-                                                : setSurveyNameSortDirection("asc");
-                                            sortByColumn("name", surveyNameSortDirection);
+                                            const nextDir: SortDirection =
+                                                surveyNameSortDirection === "asc" ? "desc" : "asc";
+                                            setSurveyNameSortDirection(nextDir);
+                                            sortByColumn("name", nextDir);
                                         }}
                                     >
                                         <span>
@@ -127,13 +127,12 @@ export const SurveyListTable: React.FC<SurveyListTableProps> = ({
                                         <>
                                             <TableCell
                                                 onClick={() => {
-                                                    startDateSortDirection === "asc"
-                                                        ? setStartDateSortDirection("desc")
-                                                        : setStartDateSortDirection("asc");
-                                                    sortByColumn(
-                                                        "startDate",
-                                                        startDateSortDirection
-                                                    );
+                                                    const nextDir: SortDirection =
+                                                        startDateSortDirection === "asc"
+                                                            ? "desc"
+                                                            : "asc";
+                                                    setStartDateSortDirection(nextDir);
+                                                    sortByColumn("startDate", nextDir);
                                                 }}
                                             >
                                                 <span>
@@ -150,10 +149,12 @@ export const SurveyListTable: React.FC<SurveyListTableProps> = ({
 
                                             <TableCell
                                                 onClick={() => {
-                                                    statusSortDirection === "asc"
-                                                        ? setStatusSortDirection("desc")
-                                                        : setStatusSortDirection("asc");
-                                                    sortByColumn("status", statusSortDirection);
+                                                    const nextDir: SortDirection =
+                                                        statusSortDirection === "asc"
+                                                            ? "desc"
+                                                            : "asc";
+                                                    setStatusSortDirection(nextDir);
+                                                    sortByColumn("status", nextDir);
                                                 }}
                                             >
                                                 <span>
@@ -171,13 +172,12 @@ export const SurveyListTable: React.FC<SurveyListTableProps> = ({
                                             {surveyFormType === "PPSSurveyForm" && (
                                                 <TableCell
                                                     onClick={() => {
-                                                        surveyTypeSortDirection === "asc"
-                                                            ? setSurveyTypeSortDirection("desc")
-                                                            : setSurveyTypeSortDirection("asc");
-                                                        sortByColumn(
-                                                            "surveyType",
-                                                            surveyTypeSortDirection
-                                                        );
+                                                        const nextDir: SortDirection =
+                                                            surveyTypeSortDirection === "asc"
+                                                                ? "desc"
+                                                                : "asc";
+                                                        setSurveyTypeSortDirection(nextDir);
+                                                        sortByColumn("surveyType", nextDir);
                                                     }}
                                                 >
                                                     <span>
@@ -197,10 +197,12 @@ export const SurveyListTable: React.FC<SurveyListTableProps> = ({
                                     {surveyFormType === "PPSWardRegister" && (
                                         <TableCell
                                             onClick={() => {
-                                                wardCodeSortDirection === "asc"
-                                                    ? setWardCodeSortDirection("desc")
-                                                    : setWardCodeSortDirection("asc");
-                                                sortByColumn("name", wardCodeSortDirection);
+                                                const nextDir: SortDirection =
+                                                    wardCodeSortDirection === "asc"
+                                                        ? "desc"
+                                                        : "asc";
+                                                setWardCodeSortDirection(nextDir);
+                                                sortByColumn("name", nextDir);
                                             }}
                                         >
                                             <span>
@@ -219,10 +221,12 @@ export const SurveyListTable: React.FC<SurveyListTableProps> = ({
                                     {surveyFormType === "PPSHospitalForm" && (
                                         <TableCell
                                             onClick={() => {
-                                                hospitalCodeSortDirection === "asc"
-                                                    ? setHospitalCodeSortDirection("desc")
-                                                    : setHospitalCodeSortDirection("asc");
-                                                sortByColumn("name", hospitalCodeSortDirection);
+                                                const nextDir: SortDirection =
+                                                    hospitalCodeSortDirection === "asc"
+                                                        ? "desc"
+                                                        : "asc";
+                                                setHospitalCodeSortDirection(nextDir);
+                                                sortByColumn("name", nextDir);
                                             }}
                                         >
                                             <span>
@@ -241,10 +245,14 @@ export const SurveyListTable: React.FC<SurveyListTableProps> = ({
                                     {SURVEYS_WITH_CHILD_COUNT.includes(surveyFormType) && (
                                         <TableCell
                                             onClick={() => {
-                                                childrenSortDirection === "asc"
-                                                    ? setChildrenSortDirection("desc")
-                                                    : setChildrenSortDirection("asc");
-                                                sortByColumn("childCount", childrenSortDirection);
+                                                const nextDir: SortDirection =
+                                                    childrenSortDirection === "asc"
+                                                        ? "desc"
+                                                        : "asc";
+                                                setChildrenSortDirection(nextDir);
+                                                const columnName =
+                                                    getChildrenName(surveyFormType)[0] || "";
+                                                sortByColumn("childCount", nextDir, columnName);
                                             }}
                                         >
                                             <span>

--- a/src/webapp/components/survey-list/table/SurveyListTable.tsx
+++ b/src/webapp/components/survey-list/table/SurveyListTable.tsx
@@ -250,9 +250,7 @@ export const SurveyListTable: React.FC<SurveyListTableProps> = ({
                                                         ? "desc"
                                                         : "asc";
                                                 setChildrenSortDirection(nextDir);
-                                                const columnName =
-                                                    getChildrenName(surveyFormType)[0] || "";
-                                                sortByColumn("childCount", nextDir, columnName);
+                                                sortByColumn("childCount", nextDir);
                                             }}
                                         >
                                             <span>

--- a/src/webapp/hooks/useSurveys.ts
+++ b/src/webapp/hooks/useSurveys.ts
@@ -7,6 +7,7 @@ import { getUserAccess } from "../../domain/utils/menuHelper";
 import { useCurrentModule } from "../contexts/current-module-context";
 import { GLOBAL_OU_ID } from "../../domain/usecases/SaveFormDataUseCase";
 import i18n from "../../utils/i18n";
+import { SortDirection } from "../components/survey-list/hook/useSurveyListActions";
 
 const PAGE_SIZE = 10;
 
@@ -20,6 +21,15 @@ const getPageSizeFromLocalStorage = (): number => {
     }
 };
 
+export type PatientSortByForForm<T extends SURVEY_FORM_TYPES> = T extends "PPSPatientRegister"
+    ? "patientId" | "patientCode"
+    : T extends "PrevalenceCaseReportForm"
+    ? "patientId"
+    : "patientId";
+
+const defaultSortBy = (surveyFormType: SURVEY_FORM_TYPES) =>
+    surveyFormType === "PPSPatientRegister" ? "patientCode" : "patientId";
+
 export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
     const { compositionRoot, prevalenceHospitals } = useAppContext();
     const [surveys, setSurveys] = useState<Survey[]>();
@@ -29,6 +39,12 @@ export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
     const [page, setPage] = useState<number>(0);
     const [pageSize, setPageSize] = useState<number>(getPageSizeFromLocalStorage());
     const [total, setTotal] = useState<number>();
+    const [sortPatientBy, setSortPatientBy] = useState<"patientId" | "patientCode">(
+        defaultSortBy(surveyFormType)
+    );
+    const [directionSortPatientId, setDirectionSortPatientId] = useState<SortDirection>("asc");
+    const [directionSortPatientCode, setDirectionSortPatientCode] = useState<SortDirection>("asc");
+
     const {
         currentPPSSurveyForm,
         currentCountryQuestionnaire,
@@ -45,6 +61,13 @@ export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
     } = useAppContext();
 
     const isAdmin = currentModule ? getUserAccess(currentModule, userGroups).hasAdminAccess : false;
+
+    useEffect(() => {
+        setSortPatientBy(defaultSortBy(surveyFormType));
+        setDirectionSortPatientId("asc");
+        setDirectionSortPatientCode("asc");
+        setPage(0);
+    }, [surveyFormType]);
 
     const getOrgUnitByFormType = useCallback(() => {
         const currentPrevalenceHospitals = prevalenceHospitals
@@ -123,6 +146,12 @@ export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
 
         //Only Patient Forms are paginated.
         if (isPaginatedSurveyList(surveyFormType)) {
+            const effectiveSortBy =
+                surveyFormType === "PPSPatientRegister" ? sortPatientBy : "patientId";
+
+            const directionSortPatientBy =
+                effectiveSortBy === "patientId" ? directionSortPatientId : directionSortPatientCode;
+
             compositionRoot.surveys.getPaginatedSurveys
                 .execute({
                     surveyFormType: surveyFormType,
@@ -133,6 +162,8 @@ export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
                     parentPatientId: currentCaseReportForm?.id,
                     page: page,
                     pageSize: pageSize,
+                    sortPatientBy: effectiveSortBy,
+                    sortDir: directionSortPatientBy,
                 })
                 .run(
                     paginatedSurveys => {
@@ -178,6 +209,9 @@ export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
         currentCaseReportForm?.id,
         currentModule,
         pageSize,
+        sortPatientBy,
+        directionSortPatientId,
+        directionSortPatientCode,
     ]);
 
     return {
@@ -191,5 +225,10 @@ export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
         setPageSize,
         total,
         setTotal,
+        directionSortPatientId,
+        setDirectionSortPatientId,
+        directionSortPatientCode,
+        setDirectionSortPatientCode,
+        setSortPatientBy,
     };
 }

--- a/src/webapp/hooks/useSurveys.ts
+++ b/src/webapp/hooks/useSurveys.ts
@@ -9,6 +9,17 @@ import { GLOBAL_OU_ID } from "../../domain/usecases/SaveFormDataUseCase";
 import i18n from "../../utils/i18n";
 
 const PAGE_SIZE = 10;
+
+const getPageSizeFromLocalStorage = (): number => {
+    try {
+        const storedPageSize = localStorage.getItem("pageSize");
+        const parsed = storedPageSize ? parseInt(storedPageSize, 10) : NaN;
+        return Number.isFinite(parsed) ? parsed : PAGE_SIZE;
+    } catch {
+        return PAGE_SIZE;
+    }
+};
+
 export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
     const { compositionRoot, prevalenceHospitals } = useAppContext();
     const [surveys, setSurveys] = useState<Survey[]>();
@@ -16,7 +27,7 @@ export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
     const [surveysError, setSurveysError] = useState<string>();
     const [shouldRefreshSurveys, setRefreshSurveys] = useState({});
     const [page, setPage] = useState<number>(0);
-    const [pageSize, setPageSize] = useState<number>(PAGE_SIZE);
+    const [pageSize, setPageSize] = useState<number>(getPageSizeFromLocalStorage());
     const [total, setTotal] = useState<number>();
     const {
         currentPPSSurveyForm,
@@ -121,13 +132,12 @@ export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
                     parentWardRegisterId: currentWardRegister?.id,
                     parentPatientId: currentCaseReportForm?.id,
                     page: page,
-                    pageSize: PAGE_SIZE,
+                    pageSize: pageSize,
                 })
                 .run(
                     paginatedSurveys => {
                         setSurveys(paginatedSurveys.objects);
                         setTotal(paginatedSurveys.pager.total);
-                        setPageSize(paginatedSurveys.pager.pageSize);
                         setLoadingSurveys(false);
                     },
                     err => {
@@ -167,6 +177,7 @@ export function useSurveys(surveyFormType: SURVEY_FORM_TYPES) {
         isAdmin,
         currentCaseReportForm?.id,
         currentModule,
+        pageSize,
     ]);
 
     return {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869c43wye [Improve case report lists](https://app.clickup.com/t/869c43wye)

### :memo: Implementation

- Fix sorting in lists columns (all lists)
- Allow to sort by patient id or code id in backend (not only currect displayed list items) in paginated list
- Allow to choose page size (10, 25 or 50) and save it in local storage 
- Fix dep-check githook changed function

### :video_camera: Screenshots/Screen capture

[Screencast from 2026-02-16 14-53-18.webm](https://github.com/user-attachments/assets/a97d5a4a-b5ef-4309-8b1c-b88d8b49f7ed)


### :fire: Notes to the tester
It seems that in PPSPatientRegister form patient code is displayed together with patient id but I don't know how to get to that list in order to test patient code sorting