### PR TITLE
[feature]: Add Ward Statistics form for Ward (only)

### DIFF
--- a/src/data/entities/D2Survey.ts
+++ b/src/data/entities/D2Survey.ts
@@ -1,4 +1,5 @@
 import { Id } from "../../domain/entities/Ref";
+import { WardStatisticsFormType } from "../../domain/entities/Survey";
 
 //PPS Program Ids
 
@@ -34,6 +35,31 @@ export const PREVALENCE_MORTALITY_DISCHARGE_CLINICAL_FORM = "ofswUbiH0PD";
 export const PREVALENCE_MORTALITY_DISCHARGE_ECONOMIC_FORM = "PsWXK0D6kT3";
 export const PREVALENCE_MORTALITY_COHORT_ENORL_FORM = "ugTEoF21u2E";
 export const WARD_SUMMARY_STATISTICS_FORM_ID = "AC5wdAzM8pI";
+export const WARD_STATISTICS_WARD_LEVEL_FORM_ID = "ZSarTKMnAGq";
+
+//Ward Statistics attribute category combos
+const AMR_WARD_ID_MED_SPE_CAT_COMBO_ID = "xVP6NkmUPA9"; // ward + specialty
+const AMR_WARD_ID_CAT_COMBO_ID = "UsL31z8VCHa"; // ward only
+
+type WardStatisticsFormConfig = {
+    dataSetId: Id;
+    attributeCategoryComboId: Id;
+    disaggregatedBySpecialty: boolean;
+};
+
+export const WARD_STATISTICS_FORM_CONFIG: Record<WardStatisticsFormType, WardStatisticsFormConfig> =
+    {
+        WardSummaryStatisticsForm: {
+            dataSetId: WARD_SUMMARY_STATISTICS_FORM_ID,
+            attributeCategoryComboId: AMR_WARD_ID_MED_SPE_CAT_COMBO_ID,
+            disaggregatedBySpecialty: true,
+        },
+        WardStatisticsForWardForm: {
+            dataSetId: WARD_STATISTICS_WARD_LEVEL_FORM_ID,
+            attributeCategoryComboId: AMR_WARD_ID_CAT_COMBO_ID,
+            disaggregatedBySpecialty: false,
+        },
+    };
 
 //old defaults
 // export const PREVALENCE_CASE_REPORT_FORM_ID = "i0msBbbQxYC";

--- a/src/data/repositories/WardEventD2Repository.ts
+++ b/src/data/repositories/WardEventD2Repository.ts
@@ -37,7 +37,7 @@ export class WardEventD2Repository implements WardEventRepository {
             surveyWardEvents: this.getSurveyWardEvents(facility),
         }).flatMap(({ categoryOptionCombos, surveyWardEvents }) => {
             const wardEvents = surveyWardEvents.map(surveyWardEvent => {
-                const wardEventDetails = getWardEventDetails(
+                const { details, unmatchedWardIds } = getWardEventDetails(
                     surveyWardEvent.events,
                     categoryOptionCombos,
                     disaggregatedBySpecialty
@@ -45,7 +45,8 @@ export class WardEventD2Repository implements WardEventRepository {
 
                 return {
                     ...surveyWardEvent,
-                    events: wardEventDetails,
+                    events: details,
+                    unmatchedWardIds,
                 };
             });
 
@@ -194,36 +195,58 @@ export type D2CategoryOptionCombo = MetadataPick<{
     categoryOptionCombos: { fields: typeof categoryOptionComboFields };
 }>["categoryOptionCombos"][number];
 
+type WardEventDetailsResult = {
+    details: WardEventDetails[];
+    unmatchedWardIds: string[];
+};
+
+type WardEventResolution =
+    | { status: "matched"; detail: WardEventDetails }
+    | { status: "unmatched"; wardId: string };
+
 export function getWardEventDetails(
     events: D2Event[],
     categoryOptionCombos: D2CategoryOptionCombo[],
     disaggregatedBySpecialty: boolean
-): WardEventDetails[] {
-    const details = _c(events)
+): WardEventDetailsResult {
+    const resolutions = _c(events)
         .flatMap(event =>
             resolveWardEventDetails(event, categoryOptionCombos, disaggregatedBySpecialty)
         )
         .value();
 
-    return disaggregatedBySpecialty
-        ? details
-        : _c(details)
+    const matchedDetails = _c(resolutions)
+        .compactMap(resolution => (resolution.status === "matched" ? resolution.detail : undefined))
+        .value();
+
+    const details = disaggregatedBySpecialty
+        ? matchedDetails
+        : _c(matchedDetails)
               .uniqBy(detail => detail.formId)
               .value();
+
+    const unmatchedWardIds = _c(resolutions)
+        .compactMap(resolution =>
+            resolution.status === "unmatched" ? resolution.wardId : undefined
+        )
+        .uniq()
+        .value();
+
+    return { details, unmatchedWardIds };
 }
 
 function resolveWardEventDetails(
     event: D2Event,
     categoryOptionCombos: D2CategoryOptionCombo[],
     disaggregatedBySpecialty: boolean
-): Collection<WardEventDetails> {
+): Collection<WardEventResolution> {
     const uniqueWardId = resolveUniqueWardId(event);
     if (!uniqueWardId) return _c([]);
 
     const specialtyCodes = disaggregatedBySpecialty ? getSpecialtyCodes(event) : [undefined];
 
-    return _c(specialtyCodes).compactMap(specialtyCode =>
-        buildWardEventDetail(uniqueWardId, specialtyCode, categoryOptionCombos)
+    return _c(specialtyCodes).map(specialtyCode =>
+        resolveWardEventDetail(uniqueWardId, specialtyCode, categoryOptionCombos)
     );
 }
 
@@ -249,11 +272,11 @@ function getSpecialtyCodes(event: D2Event): string[] {
         .value();
 }
 
-function buildWardEventDetail(
+function resolveWardEventDetail(
     wardId: string,
     specialtyCode: Maybe<string>,
     categoryOptionCombos: D2CategoryOptionCombo[]
-): Maybe<WardEventDetails> {
+): WardEventResolution {
     const wardEventCoc = categoryOptionCombos.find(coc => {
         const cocNames = coc.categoryOptions.map(co => co.name);
         const hasWardId = cocNames.some(cocName => wardId.endsWith(cocName));
@@ -267,12 +290,15 @@ function buildWardEventDetail(
         console.warn(
             `No matching category option combo for ward event with ward ID ${wardId}${specialtySuffix}`
         );
-        return undefined;
+        return { status: "unmatched", wardId };
     }
 
-    return specialtyCode
-        ? { formId: wardEventCoc.id, wardId, specialtyCode }
-        : { formId: wardEventCoc.id, wardId };
+    return {
+        status: "matched",
+        detail: specialtyCode
+            ? { formId: wardEventCoc.id, wardId, specialtyCode }
+            : { formId: wardEventCoc.id, wardId },
+    };
 }
 
 const countryLevel = 3;

--- a/src/data/repositories/WardEventD2Repository.ts
+++ b/src/data/repositories/WardEventD2Repository.ts
@@ -19,7 +19,7 @@ import { getOrgUnitByLevel } from "../../domain/entities/OrgUnit";
 import { WardStatisticsFormType } from "../../domain/entities/Survey";
 import { Maybe } from "../../utils/ts-utils";
 
-type D2Event = {
+export type D2Event = {
     event: Id;
     programStage: Id;
     dataValues: D2DataValue[];
@@ -148,12 +148,12 @@ export class WardEventD2Repository implements WardEventRepository {
     }
 }
 
-const dataElementIds = {
+export const dataElementIds = {
     WARD_ID: "yAA33dsnWmY",
     WARD_TYPE_11: "iowb9y894y2",
     WARD_TYPE_112: "yoctlOcQ4jK",
 };
-const WARD_DATA_PROGRAM_STAGE_ID = "ikaExmORX0F";
+export const WARD_DATA_PROGRAM_STAGE_ID = "ikaExmORX0F";
 const WARD_COUNT = 32;
 const generateWardIds = (count: number): string[] =>
     Array.from({ length: count }, (_, i) => `W${String(i + 1).padStart(2, "0")}`);
@@ -190,11 +190,11 @@ const trackedEntityFields = {
     trackedEntity: true,
 } as const;
 
-type D2CategoryOptionCombo = MetadataPick<{
+export type D2CategoryOptionCombo = MetadataPick<{
     categoryOptionCombos: { fields: typeof categoryOptionComboFields };
 }>["categoryOptionCombos"][number];
 
-function getWardEventDetails(
+export function getWardEventDetails(
     events: D2Event[],
     categoryOptionCombos: D2CategoryOptionCombo[],
     disaggregatedBySpecialty: boolean

--- a/src/data/repositories/WardEventD2Repository.ts
+++ b/src/data/repositories/WardEventD2Repository.ts
@@ -10,11 +10,14 @@ import {
     PREVALENCE_SURVEY_FORM_ID,
     PREVALENCE_SURVEY_NAME_DATAELEMENT_ID,
     SURVEY_ID_FACILITY_LEVEL_DATAELEMENT_ID,
+    WARD_STATISTICS_FORM_CONFIG,
 } from "../entities/D2Survey";
 import { DataValue as D2DataValue } from "@eyeseetea/d2-api/api/trackerEvents";
-import _c from "../../domain/entities/generic/Collection";
+import _c, { Collection } from "../../domain/entities/generic/Collection";
 import { OrgUnitAccess } from "../../domain/entities/User";
 import { getOrgUnitByLevel } from "../../domain/entities/OrgUnit";
+import { WardStatisticsFormType } from "../../domain/entities/Survey";
+import { Maybe } from "../../utils/ts-utils";
 
 type D2Event = {
     event: Id;
@@ -25,15 +28,19 @@ type D2Event = {
 export class WardEventD2Repository implements WardEventRepository {
     constructor(private api: D2Api) {}
 
-    get(facility: OrgUnitAccess): FutureData<WardEvent[]> {
+    get(facility: OrgUnitAccess, wardFormType: WardStatisticsFormType): FutureData<WardEvent[]> {
+        const { attributeCategoryComboId, disaggregatedBySpecialty } =
+            WARD_STATISTICS_FORM_CONFIG[wardFormType];
+
         return Future.joinObj({
-            categoryOptionCombos: this.getWardCocs(),
+            categoryOptionCombos: this.getWardCocs(attributeCategoryComboId),
             surveyWardEvents: this.getSurveyWardEvents(facility),
         }).flatMap(({ categoryOptionCombos, surveyWardEvents }) => {
             const wardEvents = surveyWardEvents.map(surveyWardEvent => {
                 const wardEventDetails = getWardEventDetails(
                     surveyWardEvent.events,
-                    categoryOptionCombos
+                    categoryOptionCombos,
+                    disaggregatedBySpecialty
                 );
 
                 return {
@@ -123,13 +130,13 @@ export class WardEventD2Repository implements WardEventRepository {
         );
     }
 
-    private getWardCocs(): FutureData<D2CategoryOptionCombo[]> {
+    private getWardCocs(categoryComboId: Id): FutureData<D2CategoryOptionCombo[]> {
         return apiToFuture(
             this.api.metadata.get({
                 categoryOptionCombos: {
                     fields: categoryOptionComboFields,
                     filter: {
-                        "categoryCombo.id": { eq: AMR_WARD_ID_MED_SPE_CAT_COMBO_ID },
+                        "categoryCombo.id": { eq: categoryComboId },
                         "categoryOptions.name": { in: generateWardIds(WARD_COUNT) },
                     },
                     paging: false,
@@ -147,7 +154,6 @@ const dataElementIds = {
     WARD_TYPE_112: "yoctlOcQ4jK",
 };
 const WARD_DATA_PROGRAM_STAGE_ID = "ikaExmORX0F";
-const AMR_WARD_ID_MED_SPE_CAT_COMBO_ID = "xVP6NkmUPA9";
 const WARD_COUNT = 32;
 const generateWardIds = (count: number): string[] =>
     Array.from({ length: count }, (_, i) => `W${String(i + 1).padStart(2, "0")}`);
@@ -190,55 +196,83 @@ type D2CategoryOptionCombo = MetadataPick<{
 
 function getWardEventDetails(
     events: D2Event[],
-    categoryOptionCombos: D2CategoryOptionCombo[]
+    categoryOptionCombos: D2CategoryOptionCombo[],
+    disaggregatedBySpecialty: boolean
 ): WardEventDetails[] {
-    return _c(events)
-        .compactMap(event => {
-            if (event.programStage !== WARD_DATA_PROGRAM_STAGE_ID) return undefined;
-
-            const getDataValue = (id: string) =>
-                event.dataValues.find(dv => dv.dataElement === id)?.value.trim();
-
-            const rawWardId = getDataValue(dataElementIds.WARD_ID);
-            const uniqueWardId = rawWardId ? normalizeWardId(rawWardId) : undefined;
-            const specialtyCode11 = getDataValue(dataElementIds.WARD_TYPE_11);
-            const specialtyCode112 = getDataValue(dataElementIds.WARD_TYPE_112);
-
-            if (uniqueWardId && (specialtyCode11 || specialtyCode112)) {
-                return _c([specialtyCode11, specialtyCode112])
-                    .compactMap(specialtyCode => {
-                        if (!specialtyCode) return undefined;
-
-                        const wardEventCoc = categoryOptionCombos.find(coc => {
-                            const cocNames = coc.categoryOptions.map(co => co.name);
-                            const hasWardId = cocNames.some(cocName =>
-                                uniqueWardId.endsWith(cocName)
-                            );
-                            const hasSpecialtyCode = cocNames.includes(specialtyCode);
-
-                            return hasWardId && hasSpecialtyCode;
-                        });
-
-                        if (!wardEventCoc) {
-                            console.warn(
-                                `No matching category option combo for ward event with ward ID ${uniqueWardId} and specialty code ${specialtyCode}`
-                            );
-                            return undefined;
-                        }
-
-                        return {
-                            formId: wardEventCoc.id,
-                            wardId: uniqueWardId,
-                            specialtyCode: specialtyCode,
-                        };
-                    })
-                    .value();
-            }
-
-            return undefined;
-        })
-        .flatten()
+    const details = _c(events)
+        .flatMap(event =>
+            resolveWardEventDetails(event, categoryOptionCombos, disaggregatedBySpecialty)
+        )
         .value();
+
+    return disaggregatedBySpecialty
+        ? details
+        : _c(details)
+              .uniqBy(detail => detail.formId)
+              .value();
+}
+
+function resolveWardEventDetails(
+    event: D2Event,
+    categoryOptionCombos: D2CategoryOptionCombo[],
+    disaggregatedBySpecialty: boolean
+): Collection<WardEventDetails> {
+    const uniqueWardId = resolveUniqueWardId(event);
+    if (!uniqueWardId) return _c([]);
+
+    const specialtyCodes = disaggregatedBySpecialty ? getSpecialtyCodes(event) : [undefined];
+
+    return _c(specialtyCodes).compactMap(specialtyCode =>
+        buildWardEventDetail(uniqueWardId, specialtyCode, categoryOptionCombos)
+    );
+}
+
+function resolveUniqueWardId(event: D2Event): Maybe<string> {
+    if (event.programStage !== WARD_DATA_PROGRAM_STAGE_ID) return undefined;
+
+    const rawWardId = event.dataValues
+        .find(dv => dv.dataElement === dataElementIds.WARD_ID)
+        ?.value.trim();
+
+    return rawWardId ? normalizeWardId(rawWardId) : undefined;
+}
+
+function getSpecialtyCodes(event: D2Event): string[] {
+    const getDataValue = (id: string) =>
+        event.dataValues.find(dv => dv.dataElement === id)?.value.trim();
+
+    return _c([
+        getDataValue(dataElementIds.WARD_TYPE_11),
+        getDataValue(dataElementIds.WARD_TYPE_112),
+    ])
+        .compact()
+        .value();
+}
+
+function buildWardEventDetail(
+    wardId: string,
+    specialtyCode: Maybe<string>,
+    categoryOptionCombos: D2CategoryOptionCombo[]
+): Maybe<WardEventDetails> {
+    const wardEventCoc = categoryOptionCombos.find(coc => {
+        const cocNames = coc.categoryOptions.map(co => co.name);
+        const hasWardId = cocNames.some(cocName => wardId.endsWith(cocName));
+        const hasSpecialtyCode = specialtyCode === undefined || cocNames.includes(specialtyCode);
+
+        return hasWardId && hasSpecialtyCode;
+    });
+
+    if (!wardEventCoc) {
+        const specialtySuffix = specialtyCode ? ` and specialty code ${specialtyCode}` : "";
+        console.warn(
+            `No matching category option combo for ward event with ward ID ${wardId}${specialtySuffix}`
+        );
+        return undefined;
+    }
+
+    return specialtyCode
+        ? { formId: wardEventCoc.id, wardId, specialtyCode }
+        : { formId: wardEventCoc.id, wardId };
 }
 
 const countryLevel = 3;

--- a/src/data/repositories/WardFormD2Repository.ts
+++ b/src/data/repositories/WardFormD2Repository.ts
@@ -1,10 +1,11 @@
 import { D2Api } from "../../types/d2-api";
 import { Column, FormValue, Row, WardForm } from "../../domain/entities/Questionnaire/WardForm";
+import { WardStatisticsFormType } from "../../domain/entities/Survey";
 import { Id, NamedRef } from "../../domain/entities/Ref";
 import { WardFormRepository } from "../../domain/repositories/WardFormRepository";
 import { apiToFuture, FutureData } from "../api-futures";
 import { Future } from "../../domain/entities/generic/Future";
-import { WARD_SUMMARY_STATISTICS_FORM_ID } from "../entities/D2Survey";
+import { WARD_STATISTICS_FORM_CONFIG } from "../entities/D2Survey";
 import _c from "../../domain/entities/generic/Collection";
 import { Maybe } from "../../utils/ts-utils";
 import { WardEventDetails } from "../../domain/entities/Questionnaire/WardEvent";
@@ -18,20 +19,30 @@ type WardSummaryDataSet = {
 export class WardFormD2Repository implements WardFormRepository {
     constructor(private api: D2Api) {}
 
-    get(facilityId: Id, period: string, wardEvents: WardEventDetails[]): FutureData<WardForm[]> {
-        return this.getWardSummaryDataSet().flatMap(dataSet =>
-            this.getDataValues(facilityId, period, wardEvents).map(dataValues =>
+    get(
+        facilityId: Id,
+        period: string,
+        wardEvents: WardEventDetails[],
+        wardFormType: WardStatisticsFormType
+    ): FutureData<WardForm[]> {
+        return this.getWardSummaryDataSet(wardFormType).flatMap(dataSet =>
+            this.getDataValues(facilityId, period, wardEvents, wardFormType).map(dataValues =>
                 this.mapToWardForms(wardEvents, dataValues, dataSet)
             )
         );
     }
 
-    save(formValue: FormValue, facilityId: Id, period: string): FutureData<void> {
+    save(
+        formValue: FormValue,
+        facilityId: Id,
+        period: string,
+        wardFormType: WardStatisticsFormType
+    ): FutureData<void> {
         return apiToFuture(
             this.api.dataValues.postSet(
                 {},
                 {
-                    dataSet: WARD_SUMMARY_STATISTICS_FORM_ID,
+                    dataSet: WARD_STATISTICS_FORM_CONFIG[wardFormType].dataSetId,
                     orgUnit: facilityId,
                     period: period,
                     attributeOptionCombo: formValue.formId,
@@ -56,11 +67,12 @@ export class WardFormD2Repository implements WardFormRepository {
     private getDataValues(
         facilityId: Id,
         period: string,
-        wardEvents: WardEventDetails[]
+        wardEvents: WardEventDetails[],
+        wardFormType: WardStatisticsFormType
     ): FutureData<FormValue[]> {
         return apiToFuture(
             this.api.dataValues.getSet({
-                dataSet: [WARD_SUMMARY_STATISTICS_FORM_ID],
+                dataSet: [WARD_STATISTICS_FORM_CONFIG[wardFormType].dataSetId],
                 orgUnit: [facilityId],
                 period: [period],
                 attributeOptionCombo: wardEvents.map(wardEvent => wardEvent.formId),
@@ -93,7 +105,9 @@ export class WardFormD2Repository implements WardFormRepository {
         formValues: FormValue[],
         dataSet: WardSummaryDataSet
     ): Maybe<WardForm> {
-        const title = `${wardEvent.wardId} - ${wardEvent.specialtyCode}`;
+        const title = wardEvent.specialtyCode
+            ? `${wardEvent.wardId} - ${wardEvent.specialtyCode}`
+            : wardEvent.wardId;
         const columns = this.getColumns(dataSet);
         const rows = this.getRows(wardEvent, formValues, dataSet, columns);
 
@@ -152,11 +166,13 @@ export class WardFormD2Repository implements WardFormRepository {
         };
     }
 
-    private getWardSummaryDataSet(): FutureData<WardSummaryDataSet> {
+    private getWardSummaryDataSet(
+        wardFormType: WardStatisticsFormType
+    ): FutureData<WardSummaryDataSet> {
         return apiToFuture(
             this.api.metadata.get({
                 dataSets: {
-                    filter: { id: { eq: WARD_SUMMARY_STATISTICS_FORM_ID } },
+                    filter: { id: { eq: WARD_STATISTICS_FORM_CONFIG[wardFormType].dataSetId } },
                     fields: dataSetFields,
                 },
             })

--- a/src/data/repositories/__tests__/WardEventD2Repository.spec.ts
+++ b/src/data/repositories/__tests__/WardEventD2Repository.spec.ts
@@ -18,12 +18,15 @@ describe("getWardEventDetails", () => {
                 givenACategoryOptionCombo("cocB", ["W01", "SPEC_B"]),
             ];
 
-            const details = getWardEventDetails([event], categoryOptionCombos, true);
+            const result = getWardEventDetails([event], categoryOptionCombos, true);
 
-            expect(details).toEqual([
-                { formId: "cocA", wardId: "W01", specialtyCode: "SPEC_A" },
-                { formId: "cocB", wardId: "W01", specialtyCode: "SPEC_B" },
-            ]);
+            expect(result).toEqual({
+                details: [
+                    { formId: "cocA", wardId: "W01", specialtyCode: "SPEC_A" },
+                    { formId: "cocB", wardId: "W01", specialtyCode: "SPEC_B" },
+                ],
+                unmatchedWardIds: [],
+            });
         });
     });
 
@@ -35,9 +38,29 @@ describe("getWardEventDetails", () => {
             ];
             const categoryOptionCombos = [givenACategoryOptionCombo("cocWardOnly", ["W01"])];
 
-            const details = getWardEventDetails(events, categoryOptionCombos, false);
+            const result = getWardEventDetails(events, categoryOptionCombos, false);
 
-            expect(details).toEqual([{ formId: "cocWardOnly", wardId: "W01" }]);
+            expect(result).toEqual({
+                details: [{ formId: "cocWardOnly", wardId: "W01" }],
+                unmatchedWardIds: [],
+            });
+        });
+    });
+
+    describe("when a ward event's category option combo doesn't match", () => {
+        it("should drop it from details and surface its ward ID in unmatchedWardIds instead of silently disappearing", () => {
+            const events = [
+                givenAWardEvent({ event: "event1", wardId: "W01" }),
+                givenAWardEvent({ event: "event2", wardId: "W02" }),
+            ];
+            const categoryOptionCombos = [givenACategoryOptionCombo("cocWardOnly", ["W01"])];
+
+            const result = getWardEventDetails(events, categoryOptionCombos, false);
+
+            expect(result).toEqual({
+                details: [{ formId: "cocWardOnly", wardId: "W01" }],
+                unmatchedWardIds: ["W02"],
+            });
         });
     });
 });

--- a/src/data/repositories/__tests__/WardEventD2Repository.spec.ts
+++ b/src/data/repositories/__tests__/WardEventD2Repository.spec.ts
@@ -1,0 +1,85 @@
+import {
+    D2CategoryOptionCombo,
+    D2Event,
+    dataElementIds,
+    getWardEventDetails,
+    WARD_DATA_PROGRAM_STAGE_ID,
+} from "../WardEventD2Repository";
+
+describe("getWardEventDetails", () => {
+    describe("when disaggregatedBySpecialty is true", () => {
+        it("should return one WardEventDetails per specialty code, each with its specialtyCode", () => {
+            const event = givenAWardEvent({
+                wardId: "W01",
+                specialtyCodes: ["SPEC_A", "SPEC_B"],
+            });
+            const categoryOptionCombos = [
+                givenACategoryOptionCombo("cocA", ["W01", "SPEC_A"]),
+                givenACategoryOptionCombo("cocB", ["W01", "SPEC_B"]),
+            ];
+
+            const details = getWardEventDetails([event], categoryOptionCombos, true);
+
+            expect(details).toEqual([
+                { formId: "cocA", wardId: "W01", specialtyCode: "SPEC_A" },
+                { formId: "cocB", wardId: "W01", specialtyCode: "SPEC_B" },
+            ]);
+        });
+    });
+
+    describe("when disaggregatedBySpecialty is false", () => {
+        it("should return a single detail with no specialtyCode, collapsing events that resolve to the same ward", () => {
+            const events = [
+                givenAWardEvent({ event: "event1", wardId: "W01" }),
+                givenAWardEvent({ event: "event2", wardId: "W01" }),
+            ];
+            const categoryOptionCombos = [givenACategoryOptionCombo("cocWardOnly", ["W01"])];
+
+            const details = getWardEventDetails(events, categoryOptionCombos, false);
+
+            expect(details).toEqual([{ formId: "cocWardOnly", wardId: "W01" }]);
+        });
+    });
+});
+
+function givenAWardEvent(options: {
+    wardId: string;
+    event?: string;
+    specialtyCodes?: [string] | [string, string];
+}): D2Event {
+    const { wardId, event = "event1", specialtyCodes = [] } = options;
+
+    return {
+        event,
+        programStage: WARD_DATA_PROGRAM_STAGE_ID,
+        dataValues: [
+            givenADataValue(dataElementIds.WARD_ID, wardId),
+            ...(specialtyCodes[0]
+                ? [givenADataValue(dataElementIds.WARD_TYPE_11, specialtyCodes[0])]
+                : []),
+            ...(specialtyCodes[1]
+                ? [givenADataValue(dataElementIds.WARD_TYPE_112, specialtyCodes[1])]
+                : []),
+        ],
+    };
+}
+
+function givenADataValue(dataElement: string, value: string): D2Event["dataValues"][number] {
+    return {
+        dataElement,
+        value,
+        updatedAt: "2024-01-01T00:00:00.000",
+        createdAt: "2024-01-01T00:00:00.000",
+        storedBy: "test-user",
+    };
+}
+
+function givenACategoryOptionCombo(
+    id: string,
+    categoryOptionNames: string[]
+): D2CategoryOptionCombo {
+    return {
+        id,
+        categoryOptions: categoryOptionNames.map(name => ({ id: name, name })),
+    };
+}

--- a/src/data/repositories/testRepositories/WardEventTestRepository.ts
+++ b/src/data/repositories/testRepositories/WardEventTestRepository.ts
@@ -19,6 +19,7 @@ export class WardEventTestRepository implements WardEventRepository {
                         wardId: "W01",
                     },
                 ],
+                unmatchedWardIds: [],
             },
         ]);
     }

--- a/src/data/repositories/testRepositories/WardEventTestRepository.ts
+++ b/src/data/repositories/testRepositories/WardEventTestRepository.ts
@@ -1,11 +1,12 @@
 import { Future } from "../../../domain/entities/generic/Future";
 import { WardEvent } from "../../../domain/entities/Questionnaire/WardEvent";
+import { WardStatisticsFormType } from "../../../domain/entities/Survey";
 import { OrgUnitAccess } from "../../../domain/entities/User";
 import { WardEventRepository } from "../../../domain/repositories/WardEventRepository";
 import { FutureData } from "../../api-futures";
 
 export class WardEventTestRepository implements WardEventRepository {
-    get(_facility: OrgUnitAccess): FutureData<WardEvent[]> {
+    get(_facility: OrgUnitAccess, _wardFormType: WardStatisticsFormType): FutureData<WardEvent[]> {
         return Future.success([
             {
                 rootSurveyId: "survey1",

--- a/src/data/repositories/testRepositories/WardFormTestRepository.ts
+++ b/src/data/repositories/testRepositories/WardFormTestRepository.ts
@@ -1,12 +1,19 @@
 import { Future } from "../../../domain/entities/generic/Future";
+import { WardEventDetails } from "../../../domain/entities/Questionnaire/WardEvent";
 import { FormValue, WardForm } from "../../../domain/entities/Questionnaire/WardForm";
+import { WardStatisticsFormType } from "../../../domain/entities/Survey";
 import { Id } from "../../../domain/entities/Ref";
 import { WardFormRepository } from "../../../domain/repositories/WardFormRepository";
 import { FutureData } from "../../api-futures";
 
 export class WardFormTestRepository implements WardFormRepository {
-    get(facilityId: string, period: string): FutureData<WardForm[]> {
-        console.debug("get ward form", facilityId, period);
+    get(
+        facilityId: string,
+        period: string,
+        _wardEvents: WardEventDetails[],
+        wardFormType: WardStatisticsFormType
+    ): FutureData<WardForm[]> {
+        console.debug("get ward form", facilityId, period, wardFormType);
 
         const wardForm: WardForm[] = [
             {
@@ -60,8 +67,13 @@ export class WardFormTestRepository implements WardFormRepository {
         return Future.success(wardForm);
     }
 
-    save(formValue: FormValue, facilityId: Id, period: string): FutureData<void> {
-        console.debug("save ward form", formValue, facilityId, period);
+    save(
+        formValue: FormValue,
+        facilityId: Id,
+        period: string,
+        wardFormType: WardStatisticsFormType
+    ): FutureData<void> {
+        console.debug("save ward form", formValue, facilityId, period, wardFormType);
         return Future.success(undefined);
     }
 }

--- a/src/domain/entities/Questionnaire/WardEvent.ts
+++ b/src/domain/entities/Questionnaire/WardEvent.ts
@@ -2,7 +2,7 @@ import { Id } from "../Ref";
 
 export type WardEventDetails = {
     formId: Id;
-    specialtyCode: string;
+    specialtyCode?: string;
     wardId: string;
 };
 

--- a/src/domain/entities/Questionnaire/WardEvent.ts
+++ b/src/domain/entities/Questionnaire/WardEvent.ts
@@ -11,4 +11,5 @@ export type WardEvent = {
     rootSurveyName: string;
     startDate: Date;
     events: WardEventDetails[];
+    unmatchedWardIds: string[];
 };

--- a/src/domain/entities/Survey.ts
+++ b/src/domain/entities/Survey.ts
@@ -20,7 +20,8 @@ export type SURVEY_FORM_TYPES =
     | "PrevalenceDischargeClinical"
     | "PrevalenceDischargeEconomic"
     | "PrevalenceCohortEnrolment"
-    | "WardSummaryStatisticsForm";
+    | "WardSummaryStatisticsForm"
+    | "WardStatisticsForWardForm";
 
 export type SURVEY_STATUSES = "FUTURE" | "ACTIVE" | "COMPLETED";
 export type SURVEY_TYPES = "SUPRANATIONAL" | "NATIONAL" | "HOSP";
@@ -41,7 +42,20 @@ export const SURVEYS_WITH_ORG_UNIT_SELECTOR: readonly SURVEY_FORM_TYPES[] = [
     "PrevalenceSurveyForm",
     "PrevalenceFacilityLevelForm",
     "WardSummaryStatisticsForm",
+    "WardStatisticsForWardForm",
 ];
+
+export type WardStatisticsFormType = "WardSummaryStatisticsForm" | "WardStatisticsForWardForm";
+
+const WARD_STATISTICS_FORM_TYPES: readonly WardStatisticsFormType[] = [
+    "WardSummaryStatisticsForm",
+    "WardStatisticsForWardForm",
+];
+
+export const isWardStatisticsFormType = (
+    formType: SURVEY_FORM_TYPES
+): formType is WardStatisticsFormType =>
+    (WARD_STATISTICS_FORM_TYPES as readonly SURVEY_FORM_TYPES[]).includes(formType);
 
 export const SURVEYS_WITH_COUNTRY_LEVEL_OU: SURVEY_FORM_TYPES[] = [
     "PPSCountryQuestionnaire",

--- a/src/domain/entities/Survey.ts
+++ b/src/domain/entities/Survey.ts
@@ -20,8 +20,7 @@ export type SURVEY_FORM_TYPES =
     | "PrevalenceDischargeClinical"
     | "PrevalenceDischargeEconomic"
     | "PrevalenceCohortEnrolment"
-    | "WardSummaryStatisticsForm"
-    | "WardStatisticsForWardForm";
+    | WardStatisticsFormType;
 
 export type SURVEY_STATUSES = "FUTURE" | "ACTIVE" | "COMPLETED";
 export type SURVEY_TYPES = "SUPRANATIONAL" | "NATIONAL" | "HOSP";
@@ -45,12 +44,12 @@ export const SURVEYS_WITH_ORG_UNIT_SELECTOR: readonly SURVEY_FORM_TYPES[] = [
     "WardStatisticsForWardForm",
 ];
 
-export type WardStatisticsFormType = "WardSummaryStatisticsForm" | "WardStatisticsForWardForm";
-
-const WARD_STATISTICS_FORM_TYPES: readonly WardStatisticsFormType[] = [
+const WARD_STATISTICS_FORM_TYPES = [
     "WardSummaryStatisticsForm",
     "WardStatisticsForWardForm",
-];
+] as const;
+
+export type WardStatisticsFormType = (typeof WARD_STATISTICS_FORM_TYPES)[number];
 
 export const isWardStatisticsFormType = (
     formType: SURVEY_FORM_TYPES

--- a/src/domain/repositories/WardEventRepository.ts
+++ b/src/domain/repositories/WardEventRepository.ts
@@ -1,7 +1,8 @@
 import { FutureData } from "../../data/api-futures";
 import { WardEvent } from "../entities/Questionnaire/WardEvent";
+import { WardStatisticsFormType } from "../entities/Survey";
 import { OrgUnitAccess } from "../entities/User";
 
 export interface WardEventRepository {
-    get(facility: OrgUnitAccess): FutureData<WardEvent[]>;
+    get(facility: OrgUnitAccess, wardFormType: WardStatisticsFormType): FutureData<WardEvent[]>;
 }

--- a/src/domain/repositories/WardFormRepository.ts
+++ b/src/domain/repositories/WardFormRepository.ts
@@ -1,9 +1,20 @@
 import { FutureData } from "../../data/api-futures";
 import { WardEventDetails } from "../entities/Questionnaire/WardEvent";
 import { FormValue, WardForm } from "../entities/Questionnaire/WardForm";
+import { WardStatisticsFormType } from "../entities/Survey";
 import { Id } from "../entities/Ref";
 
 export interface WardFormRepository {
-    get(facilityId: Id, period: string, wardEvents: WardEventDetails[]): FutureData<WardForm[]>;
-    save(formValue: FormValue, facilityId: Id, period: string): FutureData<void>;
+    get(
+        facilityId: Id,
+        period: string,
+        wardEvents: WardEventDetails[],
+        wardFormType: WardStatisticsFormType
+    ): FutureData<WardForm[]>;
+    save(
+        formValue: FormValue,
+        facilityId: Id,
+        period: string,
+        wardFormType: WardStatisticsFormType
+    ): FutureData<void>;
 }

--- a/src/domain/usecases/GetWardEventsUseCase.ts
+++ b/src/domain/usecases/GetWardEventsUseCase.ts
@@ -1,10 +1,11 @@
+import { WardStatisticsFormType } from "../entities/Survey";
 import { OrgUnitAccess } from "../entities/User";
 import { WardEventRepository } from "../repositories/WardEventRepository";
 
 export class GetWardEventsUseCase {
     constructor(private wardEventRepository: WardEventRepository) {}
 
-    public execute(orgUnit: OrgUnitAccess) {
-        return this.wardEventRepository.get(orgUnit);
+    public execute(orgUnit: OrgUnitAccess, wardFormType: WardStatisticsFormType) {
+        return this.wardEventRepository.get(orgUnit, wardFormType);
     }
 }

--- a/src/domain/usecases/GetWardFormUseCase.ts
+++ b/src/domain/usecases/GetWardFormUseCase.ts
@@ -1,6 +1,7 @@
 import { FutureData } from "../../data/api-futures";
 import { WardEventDetails } from "../entities/Questionnaire/WardEvent";
 import { WardForm } from "../entities/Questionnaire/WardForm";
+import { WardStatisticsFormType } from "../entities/Survey";
 import { Id } from "../entities/Ref";
 import { WardFormRepository } from "../repositories/WardFormRepository";
 
@@ -10,8 +11,9 @@ export class GetWardFormUseCase {
     public execute(
         facilityId: Id,
         period: string,
-        wardEvents: WardEventDetails[]
+        wardEvents: WardEventDetails[],
+        wardFormType: WardStatisticsFormType
     ): FutureData<WardForm[]> {
-        return this.wardFormRepository.get(facilityId, period, wardEvents);
+        return this.wardFormRepository.get(facilityId, period, wardEvents, wardFormType);
     }
 }

--- a/src/domain/usecases/SaveWardFormUseCase.ts
+++ b/src/domain/usecases/SaveWardFormUseCase.ts
@@ -1,12 +1,18 @@
 import { FutureData } from "../../data/api-futures";
 import { FormValue } from "../entities/Questionnaire/WardForm";
+import { WardStatisticsFormType } from "../entities/Survey";
 import { Id } from "../entities/Ref";
 import { WardFormRepository } from "../repositories/WardFormRepository";
 
 export class SaveWardFormUseCase {
     constructor(private wardFormRepository: WardFormRepository) {}
 
-    public execute(formValue: FormValue, facilityId: Id, period: string): FutureData<void> {
-        return this.wardFormRepository.save(formValue, facilityId, period);
+    public execute(
+        formValue: FormValue,
+        facilityId: Id,
+        period: string,
+        wardFormType: WardStatisticsFormType
+    ): FutureData<void> {
+        return this.wardFormRepository.save(formValue, facilityId, period, wardFormType);
     }
 }

--- a/src/domain/utils/PPSProgramsHelper.ts
+++ b/src/domain/utils/PPSProgramsHelper.ts
@@ -183,7 +183,9 @@ export const getSurveyDisplayName = (surveyFormType: SURVEY_FORM_TYPES): string 
         case "PrevalenceCohortEnrolment":
             return "Cohort Enrolment";
         case "WardSummaryStatisticsForm":
-            return "Ward Summary Statistics";
+            return "Ward Statistics for Ward & Specialty";
+        case "WardStatisticsForWardForm":
+            return "Ward Statistics for Ward";
         default:
             return "Survey";
     }

--- a/src/webapp/components/survey/SurveyForm.tsx
+++ b/src/webapp/components/survey/SurveyForm.tsx
@@ -4,7 +4,7 @@ import i18n from "@eyeseetea/d2-ui-components/locales";
 import { useSurveyForm } from "./hook/useSurveyForm";
 import { red300 } from "material-ui/styles/colors";
 import { Id } from "../../../domain/entities/Ref";
-import { SURVEY_FORM_TYPES } from "../../../domain/entities/Survey";
+import { isWardStatisticsFormType, SURVEY_FORM_TYPES } from "../../../domain/entities/Survey";
 import { ContentLoader } from "../content-loader/ContentLoader";
 import { useSaveSurvey } from "./hook/useSaveSurvey";
 import styled from "styled-components";
@@ -131,8 +131,12 @@ export const SurveyForm: React.FC<SurveyFormProps> = props => {
             <ContentLoader loading={loading} error={error} showErrorAsSnackbar={true}>
                 <Title variant="h5">{i18n.t(getSurveyDisplayName(props.formType) || "")}</Title>
 
-                {props.formType === "WardSummaryStatisticsForm" ? (
-                    <WardSummaryForm hasReadOnlyAccess={hasReadOnlyAccess} />
+                {isWardStatisticsFormType(props.formType) ? (
+                    <WardSummaryForm
+                        key={props.formType}
+                        formType={props.formType}
+                        hasReadOnlyAccess={hasReadOnlyAccess}
+                    />
                 ) : (
                     <>
                         <SurveyFormOUSelector
@@ -249,7 +253,7 @@ export const SurveyForm: React.FC<SurveyFormProps> = props => {
                 )}
             </ContentLoader>
 
-            {props.formType !== "WardSummaryStatisticsForm" && (
+            {!isWardStatisticsFormType(props.formType) && (
                 <PageFooter>
                     <CancelButton variant="outlined" onClick={onCancel}>
                         {i18n.t("Cancel")}

--- a/src/webapp/components/survey/SurveyFormOUSelector.tsx
+++ b/src/webapp/components/survey/SurveyFormOUSelector.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo } from "react";
 import { COUNTRY_OU_LEVEL, HOSPITAL_OU_LEVELS } from "../../../data/repositories/UserD2Repository";
 import { Id } from "../../../domain/entities/Ref";
 import {
+    isWardStatisticsFormType,
     SURVEYS_WITH_COUNTRY_LEVEL_OU,
     SURVEYS_WITH_ORG_UNIT_SELECTOR,
     SURVEY_FORM_TYPES,
@@ -62,7 +63,7 @@ export const SurveyFormOUSelector: React.FC<SurveyFormOUSelectorProps> = ({
             return [currentPrevalenceSurveyForm?.orgUnitId];
         }
 
-        if (formType === "WardSummaryStatisticsForm") {
+        if (isWardStatisticsFormType(formType)) {
             return getRootIds(currentUser.organisationUnits);
         }
 

--- a/src/webapp/components/survey/hook/useSurveyForm.ts
+++ b/src/webapp/components/survey/hook/useSurveyForm.ts
@@ -5,6 +5,7 @@ import {
     QuestionnaireStage,
 } from "../../../../domain/entities/Questionnaire/Questionnaire";
 import {
+    isWardStatisticsFormType,
     SURVEYS_WITH_ORG_UNIT_SELECTOR,
     SURVEY_FORM_TYPES,
 } from "../../../../domain/entities/Survey";
@@ -63,7 +64,7 @@ export function useSurveyForm(formType: SURVEY_FORM_TYPES, eventId: string | und
 
     useEffect(() => {
         setLoading(true);
-        if (formType === "WardSummaryStatisticsForm") {
+        if (isWardStatisticsFormType(formType)) {
             setLoading(false);
             return;
         }

--- a/src/webapp/components/survey/hook/useSurveyFormOUSelector.ts
+++ b/src/webapp/components/survey/hook/useSurveyFormOUSelector.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import { Id } from "../../../../domain/entities/Ref";
-import { SURVEY_FORM_TYPES } from "../../../../domain/entities/Survey";
+import { isWardStatisticsFormType, SURVEY_FORM_TYPES } from "../../../../domain/entities/Survey";
 import { OrgUnitAccess } from "../../../../domain/entities/User";
 import { useAppContext } from "../../../contexts/app-context";
 import { Maybe } from "../../../../utils/ts-utils";
@@ -44,7 +44,7 @@ export function useSurveyFormOUSelector(
                         }
                     } else if (
                         formType === "PrevalenceFacilityLevelForm" ||
-                        formType === "WardSummaryStatisticsForm"
+                        isWardStatisticsFormType(formType)
                     ) {
                         const currentHospital = prevalenceHospitals.find(
                             hospital => hospital.orgUnitId === selectedOU

--- a/src/webapp/components/ward-summary-form/WardSummaryForm.tsx
+++ b/src/webapp/components/ward-summary-form/WardSummaryForm.tsx
@@ -10,13 +10,16 @@ import { Id } from "../../../domain/entities/Ref";
 import i18n from "../../../utils/i18n";
 import { SurveyFormOUSelector } from "../survey/SurveyFormOUSelector";
 import { WardEvent } from "../../../domain/entities/Questionnaire/WardEvent";
+import { WardStatisticsFormType } from "../../../domain/entities/Survey";
 
 type WardSummaryFormProps = {
+    formType: WardStatisticsFormType;
     hasReadOnlyAccess: boolean;
 };
 
 export const WardSummaryForm: React.FC<WardSummaryFormProps> = props => {
-    const { hasReadOnlyAccess } = props;
+    const { formType, hasReadOnlyAccess } = props;
+
     const {
         currentOrgUnit,
         error,
@@ -31,13 +34,13 @@ export const WardSummaryForm: React.FC<WardSummaryFormProps> = props => {
         saveWardSummaryForm,
         updateRootSurvey,
         updateWardSummaryPeriod,
-    } = useWardSummaryForm();
+    } = useWardSummaryForm(formType);
     const selectablePeriods = useSelectablePeriods(selectedRootSurvey, wardEvents);
 
     return (
         <Container>
             <SurveyFormOUSelector
-                formType={"WardSummaryStatisticsForm"}
+                formType={formType}
                 currentOrgUnit={currentOrgUnit}
                 setCurrentOrgUnit={saveCurrentOrgUnit}
                 currentSurveyId={undefined}

--- a/src/webapp/components/ward-summary-form/hooks/useWardSummaryForm.tsx
+++ b/src/webapp/components/ward-summary-form/hooks/useWardSummaryForm.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { FormValue, WardForm } from "../../../../domain/entities/Questionnaire/WardForm";
+import { WardStatisticsFormType } from "../../../../domain/entities/Survey";
 import { useAppContext } from "../../../contexts/app-context";
 import { Maybe } from "../../../../utils/ts-utils";
 import { Id } from "../../../../domain/entities/Ref";
@@ -15,7 +16,7 @@ export enum SAVE_FORM_STATE {
     SUCCESS = "success",
 }
 
-export function useWardSummaryForm() {
+export function useWardSummaryForm(wardFormType: WardStatisticsFormType) {
     const { compositionRoot } = useAppContext();
 
     const [cellSaveStates, setCellSaveStates] = useState<Map<string, SAVE_FORM_STATE>>(new Map());
@@ -62,7 +63,7 @@ export function useWardSummaryForm() {
             }
             setLoading(true);
             compositionRoot.surveys.getWardForm
-                .execute(currentOrgUnit.orgUnitId, selectedPeriod, wardEventDetails)
+                .execute(currentOrgUnit.orgUnitId, selectedPeriod, wardEventDetails, wardFormType)
                 .run(
                     wardSummaryForm => {
                         setWardSummaryForm(wardSummaryForm);
@@ -74,7 +75,14 @@ export function useWardSummaryForm() {
                     }
                 );
         }
-    }, [currentOrgUnit, selectedPeriod, compositionRoot.surveys, wardEvents, selectedRootSurvey]);
+    }, [
+        currentOrgUnit,
+        selectedPeriod,
+        compositionRoot.surveys,
+        wardEvents,
+        selectedRootSurvey,
+        wardFormType,
+    ]);
 
     const rootSurveyOptions = useMemo(
         () =>
@@ -108,7 +116,7 @@ export function useWardSummaryForm() {
             setWardEvents(undefined);
             setError(undefined);
             setLoading(true);
-            compositionRoot.surveys.getWardEvents.execute(orgUnit).run(
+            compositionRoot.surveys.getWardEvents.execute(orgUnit, wardFormType).run(
                 wardEvents => {
                     setWardEvents(wardEvents);
                     setCurrentOrgUnit(orgUnit);
@@ -121,7 +129,7 @@ export function useWardSummaryForm() {
                 }
             );
         },
-        [compositionRoot.surveys.getWardEvents]
+        [compositionRoot.surveys.getWardEvents, wardFormType]
     );
 
     const updateCellSaveState = useCallback((formValue: FormValue, state: SAVE_FORM_STATE) => {
@@ -145,7 +153,7 @@ export function useWardSummaryForm() {
 
             const formValueToSave = { ...formValue, value: newValue ?? "" };
             compositionRoot.surveys.saveWardForm
-                .execute(formValueToSave, currentOrgUnit.orgUnitId, selectedPeriod)
+                .execute(formValueToSave, currentOrgUnit.orgUnitId, selectedPeriod, wardFormType)
                 .run(
                     () => {
                         updateCellSaveState(formValue, SAVE_FORM_STATE.SUCCESS);
@@ -156,7 +164,13 @@ export function useWardSummaryForm() {
                     }
                 );
         },
-        [updateCellSaveState, currentOrgUnit, selectedPeriod, compositionRoot.surveys.saveWardForm]
+        [
+            updateCellSaveState,
+            currentOrgUnit,
+            selectedPeriod,
+            compositionRoot.surveys.saveWardForm,
+            wardFormType,
+        ]
     );
 
     const updateWardSummaryPeriod = useCallback((period: Maybe<Id>) => {

--- a/src/webapp/components/ward-summary-form/hooks/useWardSummaryForm.tsx
+++ b/src/webapp/components/ward-summary-form/hooks/useWardSummaryForm.tsx
@@ -8,6 +8,9 @@ import { getCellId } from "../WardSummarySection";
 import { palette } from "../../../pages/app/themes/dhis2.theme";
 import { OrgUnitAccess } from "../../../../domain/entities/User";
 import { WardEvent } from "../../../../domain/entities/Questionnaire/WardEvent";
+import { useOfflineSnackbar } from "../../../hooks/useOfflineSnackbar";
+import i18n from "../../../../utils/i18n";
+import _c from "../../../../domain/entities/generic/Collection";
 
 export enum SAVE_FORM_STATE {
     ERROR = "error",
@@ -18,6 +21,7 @@ export enum SAVE_FORM_STATE {
 
 export function useWardSummaryForm(wardFormType: WardStatisticsFormType) {
     const { compositionRoot } = useAppContext();
+    const { snackbar } = useOfflineSnackbar();
 
     const [cellSaveStates, setCellSaveStates] = useState<Map<string, SAVE_FORM_STATE>>(new Map());
     const [currentOrgUnit, setCurrentOrgUnit] = useState<OrgUnitAccess>();
@@ -122,6 +126,7 @@ export function useWardSummaryForm(wardFormType: WardStatisticsFormType) {
                     setCurrentOrgUnit(orgUnit);
                     if (wardEvents.length === 1) setSelectedRootSurvey(wardEvents[0]?.rootSurveyId);
                     setLoading(false);
+                    warnAboutUnmatchedWardIds(wardEvents, snackbar.warning);
                 },
                 error => {
                     setError(error.message);
@@ -129,7 +134,7 @@ export function useWardSummaryForm(wardFormType: WardStatisticsFormType) {
                 }
             );
         },
-        [compositionRoot.surveys.getWardEvents, wardFormType]
+        [compositionRoot.surveys.getWardEvents, wardFormType, snackbar]
     );
 
     const updateCellSaveState = useCallback((formValue: FormValue, state: SAVE_FORM_STATE) => {
@@ -200,4 +205,20 @@ export function useWardSummaryForm(wardFormType: WardStatisticsFormType) {
         updateRootSurvey: updateRootSurvey,
         updateWardSummaryPeriod: updateWardSummaryPeriod,
     };
+}
+
+function warnAboutUnmatchedWardIds(wardEvents: WardEvent[], warn: (message: string) => void): void {
+    const unmatchedWardIds = _c(wardEvents)
+        .flatMap(wardEvent => _c(wardEvent.unmatchedWardIds))
+        .uniq()
+        .value();
+
+    if (unmatchedWardIds.length === 0) return;
+
+    warn(
+        i18n.t(
+            "Some ward events could not be matched to a form and were not included: {{wardIds}}",
+            { wardIds: unmatchedWardIds.join(", ") }
+        )
+    );
 }

--- a/src/webapp/hooks/useMenu.ts
+++ b/src/webapp/hooks/useMenu.ts
@@ -43,11 +43,17 @@ export function useMenu() {
                         module: m,
                     },
                 ];
-                const wardSummaryStatisticsFormMenu: MenuLeaf[] = [
+                const wardStatisticsFormMenus: MenuLeaf[] = [
                     {
                         kind: "MenuLeaf",
-                        title: "Ward Summary Statistics",
+                        title: "Ward Statistics for Ward & Specialty",
                         path: `/new-survey/WardSummaryStatisticsForm`,
+                        module: m,
+                    },
+                    {
+                        kind: "MenuLeaf",
+                        title: "Ward Statistics for Ward",
+                        path: `/new-survey/WardStatisticsForWardForm`,
                         module: m,
                     },
                 ];
@@ -58,7 +64,7 @@ export function useMenu() {
                     moduleColor: m.color,
                     children:
                         surveyFormType === "PrevalenceSurveyForm"
-                            ? [...childMenus, ...wardSummaryStatisticsFormMenu]
+                            ? [...childMenus, ...wardStatisticsFormMenus]
                             : childMenus,
                 };
             });

--- a/src/webapp/pages/survey/SurveyPage.tsx
+++ b/src/webapp/pages/survey/SurveyPage.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useHistory, useParams } from "react-router-dom";
 import styled from "styled-components";
 
-import { SURVEY_FORM_TYPES } from "../../../domain/entities/Survey";
+import { isWardStatisticsFormType, SURVEY_FORM_TYPES } from "../../../domain/entities/Survey";
 import { SurveyForm } from "../../components/survey/SurveyForm";
 import { PPSSurveyFormBreadCrumb } from "../../components/survey/bread-crumbs/PPSSurveyFormBreadCrumb";
 import { useCurrentModule } from "../../contexts/current-module-context";
@@ -22,7 +22,7 @@ export const SurveyPage: React.FC = () => {
             {currentModule?.name === "PPS" && (
                 <PPSSurveyFormBreadCrumb formType={formType} id={id} />
             )}
-            {currentModule?.name === "Prevalence" && formType !== "WardSummaryStatisticsForm" && (
+            {currentModule?.name === "Prevalence" && !isWardStatisticsFormType(formType) && (
                 <PrevalenceSurveyFormBreadCrumb formType={formType} id={id} />
             )}
             <SurveyForm hideForm={hideForm} formType={formType} currentSurveyId={id} />


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [869e1vvu3](https://app.clickup.com/t/4528615/869e1vvu3)

### :memo: Implementation
This PR adds a second ward-statistics data-entry form, **Ward Statistics for Ward**, next to the existing statistics form (renamed to **Ward Statistics for Ward & Specialty**). Both forms share the same UI and flow; they differ only in which DHIS2 dataset and attribute category combo they fill.

-   Introduced a `WardStatisticsDefinition` (`"WardAndSpecialty" | "Ward"`) and a single source of truth mapping each ward form type to its dataset/attribute combo config (`WARD_STATISTICS_FORM_CONFIG`, `WARD_STATISTICS_FORM_DEFINITIONS`).
-   Threaded the `formType` through the Ward event/form repositories, use cases, and the `useWardSummaryForm` hook so the correct dataset (`WARD_STATISTICS_WARD_LEVEL_FORM_ID`) and category combo (`AMR_WARD_ID_CAT_COMBO_ID`) are queried and saved.
-   Replaced the hardcoded `formType === "WardSummaryStatisticsForm"` checks with a `isWardStatisticsFormType` type guard, added the new menu entry under Prevalence, and keyed `WardSummaryForm` by form type so switching datasets remounts and resets state.

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/26112d66-680e-4fda-acfd-972848893f75


### :fire: Notes to the tester
-   Verify the Prevalence menu now shows both **Ward Statistics for Ward & Specialty** and **Ward Statistics for Ward**.
-   For each form, select an org unit / root survey / period and confirm the correct forms load, values save, and cell save-state indicators work.
-   Confirm the **Ward** form shows one form per ward (no specialty in the title) and the **Ward & Specialty** form is unchanged.
-   Switch between the two forms and confirm state resets (previously loaded ward events don't leak across).
-   Requires the DHIS2 dataset `ZSarTKMnAGq` and category combo `UsL31z8VCHa` to exist and be assigned in the instance under test.

#869e1vvu3